### PR TITLE
1.3.76

### DIFF
--- a/DomainManagement/DomainManagement.psd1
+++ b/DomainManagement/DomainManagement.psd1
@@ -3,7 +3,7 @@
 	RootModule         = 'DomainManagement.psm1'
 	
 	# Version number of this module.
-	ModuleVersion      = '1.3.75'
+	ModuleVersion      = '1.3.76'
 	
 	# ID used to uniquely identify this module
 	GUID               = '0a405382-ebc2-445b-8325-541535810193'

--- a/DomainManagement/DomainManagement.psd1
+++ b/DomainManagement/DomainManagement.psd1
@@ -95,6 +95,7 @@
 		'Register-DMOrganizationalUnit'
 		'Register-DMPasswordPolicy'
 		'Register-DMUser'
+		'Reset-DMDomainCredential'
 		'Resolve-DMAccessRuleMode'
 		'Resolve-DMObjectCategory'
 		'Set-DMContentMode'

--- a/DomainManagement/DomainManagement.psd1
+++ b/DomainManagement/DomainManagement.psd1
@@ -3,7 +3,7 @@
 	RootModule         = 'DomainManagement.psm1'
 	
 	# Version number of this module.
-	ModuleVersion      = '1.3.70'
+	ModuleVersion      = '1.3.75'
 	
 	# ID used to uniquely identify this module
 	GUID               = '0a405382-ebc2-445b-8325-541535810193'

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -1,7 +1,8 @@
 ﻿# Changelog
 
-## 1.3.75 (2020-07-31)
+## 1.3.76 (2020-07-31)
 
+- New: Reset-DMDomainCredential - Resets cached credentials for contacting domains.
 - Upd: Component Group Membership - now can define Group Processing Mode, introducing Constrained and Additive Modes to a group's memberships.
 - Upd: Component Group Membership - configured names may now include SIDs, such as the SIDs of built-in accounts or groups.
 - Fix: Register-DMGroupMembership - explicitly registering empty as $false no longer clears configured settings.

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -3,6 +3,7 @@
 ## ???
 
 - Upd: Component Group Membership - now can define Group Processing Mode, introducing Constrained and Additive Modes to a group's memberships.
+- Upd: Component Group Membership - configured names may now include SIDs, such as the SIDs of built-in accounts or groups.
 - Fix: Register-DMGroupMembership - explicitly registering empty as $false no longer clears configured settings.
 
 ## 1.3.70 (2020-06-12)

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -5,6 +5,7 @@
 - Upd: Component Group Membership - now can define Group Processing Mode, introducing Constrained and Additive Modes to a group's memberships.
 - Upd: Component Group Membership - configured names may now include SIDs, such as the SIDs of built-in accounts or groups.
 - Fix: Register-DMGroupMembership - explicitly registering empty as $false no longer clears configured settings.
+- Fix: Invoke-DMPasswordPolicy - disabled per-item confirmation prompt
 
 ## 1.3.70 (2020-06-12)
 

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -27,7 +27,6 @@
 
 ## 1.3.63 (2020-04-20)
 
-- New: Reset-DMDomainCredential - resets cached credentials for connecting to ad domains.
 - Fix: All Invokes broken
 
 ## 1.3.62 (2020-04-17)

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -1,6 +1,6 @@
 ﻿# Changelog
 
-## ???
+## 1.3.75 (2020-07-31)
 
 - Upd: Component Group Membership - now can define Group Processing Mode, introducing Constrained and Additive Modes to a group's memberships.
 - Upd: Component Group Membership - configured names may now include SIDs, such as the SIDs of built-in accounts or groups.

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -1,5 +1,10 @@
 ﻿# Changelog
 
+## ???
+
+- Upd: Component Group Membership - now can define Group Processing Mode, introducing Constrained and Additive Modes to a group's memberships.
+- Fix: Register-DMGroupMembership - explicitly registering empty as $false no longer clears configured settings.
+
 ## 1.3.70 (2020-06-12)
 
 - Upd: Test-DMAcl - supports SIDs for Ownership.
@@ -18,6 +23,7 @@
 
 ## 1.3.63 (2020-04-20)
 
+- New: Reset-DMDomainCredential - resets cached credentials for connecting to ad domains.
 - Fix: All Invokes broken
 
 ## 1.3.62 (2020-04-17)

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -6,6 +6,7 @@
 - Upd: Component Group Membership - configured names may now include SIDs, such as the SIDs of built-in accounts or groups.
 - Fix: Register-DMGroupMembership - explicitly registering empty as $false no longer clears configured settings.
 - Fix: Invoke-DMPasswordPolicy - disabled per-item confirmation prompt
+- Fix: Invoke-DMOrganizationalUnit - fixed processing order
 
 ## 1.3.70 (2020-06-12)
 

--- a/DomainManagement/functions/AccessRuleMode/Resolve-DMAccessRuleMode.ps1
+++ b/DomainManagement/functions/AccessRuleMode/Resolve-DMAccessRuleMode.ps1
@@ -21,6 +21,7 @@
 
 		Resolves the AccessRule processing mode that applies to the specified ADObject.
 	#>
+	[OutputType([string])]
 	[CmdletBinding()]
 	Param (
 		[Parameter(Mandatory = $true)]

--- a/DomainManagement/functions/gplinks/Get-DMGPLink.ps1
+++ b/DomainManagement/functions/gplinks/Get-DMGPLink.ps1
@@ -19,6 +19,7 @@
 
 		Returns all registered GPLinks
 	#>
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "")]
 	[CmdletBinding()]
 	param (
 		[string]

--- a/DomainManagement/functions/gppermissions/Register-DMGPPermission.ps1
+++ b/DomainManagement/functions/gppermissions/Register-DMGPPermission.ps1
@@ -70,6 +70,7 @@
 
 		Reads all settings from the provided json file and registers them.
 	#>
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "")]
 	[CmdletBinding()]
 	param (
 		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Explicit')]

--- a/DomainManagement/functions/gppermissions/Test-DMGPPermission.ps1
+++ b/DomainManagement/functions/gppermissions/Test-DMGPPermission.ps1
@@ -22,6 +22,7 @@
 
 		Tests whether the domain of corp.contoso.com has the desired GP Permission configuration.
 	#>
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseUsingScopeModifierInNewRunspaces", "")]
 	[CmdletBinding()]
 	param (
 		[PSFComputer]

--- a/DomainManagement/functions/gpregistrysettings/Get-DMGPRegistrySetting.ps1
+++ b/DomainManagement/functions/gpregistrysettings/Get-DMGPRegistrySetting.ps1
@@ -20,6 +20,7 @@
 
 		Returns all registered group policy registry settings.
 	#>
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "")]
 	[CmdletBinding()]
 	Param (
 		[Parameter(ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]

--- a/DomainManagement/functions/gpregistrysettings/Test-DMGPRegistrySetting.ps1
+++ b/DomainManagement/functions/gpregistrysettings/Test-DMGPRegistrySetting.ps1
@@ -29,6 +29,7 @@
 
 		Tests, whether the specified GPO has all the desired registry keys configured.
 	#>
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseUsingScopeModifierInNewRunspaces", "")]
 	[CmdletBinding()]
 	Param (
 		[Parameter(Mandatory = $true)]

--- a/DomainManagement/functions/groupmemberships/Get-DMGroupMembership.ps1
+++ b/DomainManagement/functions/groupmemberships/Get-DMGroupMembership.ps1
@@ -18,7 +18,7 @@
 
 		List all configured group memberships.
 	#>
-	
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "")]
 	[CmdletBinding()]
 	param (
 		[string]

--- a/DomainManagement/functions/groupmemberships/Invoke-DMGroupMembership.ps1
+++ b/DomainManagement/functions/groupmemberships/Invoke-DMGroupMembership.ps1
@@ -87,10 +87,16 @@
 				$group = New-Object DirectoryServices.DirectoryEntry($path)
 			}
 			[void]$group.member.Add("<SID=$SID>")
-			$group.CommitChanges()
-			$group.Close()
+			try { $group.CommitChanges() }
+			catch
+			{
+				if (-not $Credential) { throw }
+				$group.Password = $Credential.GetNetworkCredential().Password
+				$group.CommitChanges()
+			}
+			finally { $group.Close() }
 		}
-
+		
 		function Remove-GroupMember {
 			[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
 			[CmdletBinding()]

--- a/DomainManagement/functions/groupmemberships/Register-DMGroupMembership.ps1
+++ b/DomainManagement/functions/groupmemberships/Register-DMGroupMembership.ps1
@@ -27,11 +27,18 @@
 		Flagging a group for being empty will clear all members from it.
 	
 	.PARAMETER Mode
-		How group memberships will be processed:
+		How the defined group membership will be processed:
 		- Default:             Member must exist and be member of the group.
 		- MayBeMember:         Principal must exist but may be a member. No add action will be generated if not a member, but also no remove action if it already is a member.
 		- MemberIfExists:      If Principal exists, make it a member.
 		- MayBeMemberIfExists: Both existence and membership are optional for this principal.
+	
+	.PARAMETER GroupProcessingMode
+		Governs how ALL group memberships on the targeted group will be processed.
+		Supported modes:
+		- Constrained: Existing Group Memberships not defined will be removed
+		- Additive: Group Memberships defined will be applied, but non-configured memberships will be ignored.
+		If no setting is defined, it will default to 'Constrained'
 	
 	.PARAMETER ContextName
 		The name of the context defining the setting.
@@ -68,9 +75,15 @@
 		[bool]
 		$Empty,
 		
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
 		[ValidateSet('Default', 'MayBeMember', 'MemberIfExists', 'MayBeMemberIfExists')]
 		[string]
 		$Mode = 'Default',
+		
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
+		[ValidateSet('Constrained', 'Additive')]
+		[string]
+		$GroupProcessingMode,
 		
 		[string]
 		$ContextName = '<Undefined>'
@@ -94,9 +107,17 @@
 				ContextName = $ContextName
 			}
 		}
-		else
+		elseif ($Empty)
 		{
 			$script:groupMemberShips[$Group] = @{ }
+		}
+		
+		if ($GroupProcessingMode)
+		{
+			$script:groupMemberShips[$Group]['__Configuration'] = [PSCustomObject]@{
+				PSTypeName = 'DomainManagement.GroupMembership.Configuration'
+				ProcessingMode = $GroupProcessingMode
+			}
 		}
 	}
 }

--- a/DomainManagement/functions/groupmemberships/Register-DMGroupMembership.ps1
+++ b/DomainManagement/functions/groupmemberships/Register-DMGroupMembership.ps1
@@ -11,6 +11,8 @@
 	
 	.PARAMETER Name
 		The name of the user or group to grant membership in the target group.
+		This parameter also accepts SIDs instead of names.
+		Note: %DomainSID% is the placeholder for the domain SID, %RootDomainSID% the one for the forest root domain.
 	
 	.PARAMETER Domain
 		Domain the entity is from, that is being granted group membership.

--- a/DomainManagement/functions/grouppolicies/Invoke-DMGroupPolicy.ps1
+++ b/DomainManagement/functions/grouppolicies/Invoke-DMGroupPolicy.ps1
@@ -45,6 +45,7 @@
 		Brings the group policy settings from the domain fabrikam.com into compliance with the desired state.
 		Will also delete all deprecated policies linked to the managed infrastructure.
 	#>
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseUsingScopeModifierInNewRunspaces", "")]
 	[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
 	param (
 		[Parameter(ValueFromPipeline = $true)]

--- a/DomainManagement/functions/organizationalunits/Invoke-DMOrganizationalUnit.ps1
+++ b/DomainManagement/functions/organizationalunits/Invoke-DMOrganizationalUnit.ps1
@@ -73,7 +73,7 @@
 	{
 		#region Sort Script
 		$sortScript = {
-			if ($_.Type -eq 'ShouldDelete') { $_.Identity.Split(",").Count }
+			if ($_.Type -eq 'ShouldDelete') { $_.ADObject.DistinguishedName.Split(",").Count }
 			else { 1000 - $_.Identity.Split(",").Count }
 		}
 		#endregion Sort Script

--- a/DomainManagement/functions/organizationalunits/Invoke-DMOrganizationalUnit.ps1
+++ b/DomainManagement/functions/organizationalunits/Invoke-DMOrganizationalUnit.ps1
@@ -69,9 +69,16 @@
 		$everyone = ([System.Security.Principal.SecurityIdentifier]'S-1-1-0').Translate([System.Security.Principal.NTAccount])
 		Set-DMDomainContext @parameters
 	}
-	process{
+	process
+	{
+		#region Sort Script
+		$sortScript = {
+			if ($_.Type -eq 'ShouldDelete') { $_.Identity.Split(",").Count }
+			else { 1000 - $_.Identity.Split(",").Count }
+		}
+		#endregion Sort Script
 		if (-not $InputObject) {
-			$InputObject = Test-DMOrganizationalUnit @parameters | Sort-Object { $_.Identity.Split(",").Count } -Descending
+			$InputObject = Test-DMOrganizationalUnit @parameters | Sort-Object $sortScript -Descending
 		}
 		
 		:main foreach ($testItem in $InputObject) {

--- a/DomainManagement/functions/organizationalunits/Invoke-DMOrganizationalUnit.ps1
+++ b/DomainManagement/functions/organizationalunits/Invoke-DMOrganizationalUnit.ps1
@@ -71,7 +71,7 @@
 	}
 	process{
 		if (-not $InputObject) {
-			$InputObject = Test-DMOrganizationalUnit @parameters | Sort-Object { $_.Identity.Split(",").Count }
+			$InputObject = Test-DMOrganizationalUnit @parameters | Sort-Object { $_.Identity.Split(",").Count } -Descending
 		}
 		
 		:main foreach ($testItem in $InputObject) {

--- a/DomainManagement/functions/passwordpolicies/Invoke-DMPasswordPolicy.ps1
+++ b/DomainManagement/functions/passwordpolicies/Invoke-DMPasswordPolicy.ps1
@@ -118,14 +118,14 @@
 						Invoke-PSFProtectedCommand -ActionString 'Invoke-DMPasswordPolicy.PSO.Update' -ActionStringValues ($changes.Keys -join ", ") -Target $testItem -ScriptBlock {
 							$parametersUpdate = $parameters.Clone()
 							$parametersUpdate += $changes
-							$null = Set-ADFineGrainedPasswordPolicy -Identity $testItem.ADObject.ObjectGUID @parametersUpdate -ErrorAction Stop
+							$null = Set-ADFineGrainedPasswordPolicy -Identity $testItem.ADObject.ObjectGUID @parametersUpdate -ErrorAction Stop -Confirm:$false
 						} -EnableException $EnableException.ToBool() -PSCmdlet $PSCmdlet -Continue
 					}
 					
 					if ($updateAssignment) {
 						Invoke-PSFProtectedCommand -ActionString 'Invoke-DMPasswordPolicy.PSO.Update.GroupAssignment' -ActionStringValues (Resolve-String -Text $testItem.Configuration.SubjectGroup) -Target $testItem -ScriptBlock {
 							if ($testItem.ADObject.AppliesTo) {
-								Remove-ADFineGrainedPasswordPolicySubject @parameters -Identity $testItem.ADObject.ObjectGUID -Subjects $testItem.ADObject.AppliesTo -ErrorAction Stop
+								Remove-ADFineGrainedPasswordPolicySubject @parameters -Identity $testItem.ADObject.ObjectGUID -Subjects $testItem.ADObject.AppliesTo -ErrorAction Stop -Confirm:$false
 							}
 							$null = Add-ADFineGrainedPasswordPolicySubject @parameters -Identity $testItem.ADObject.ObjectGUID -Subjects (Resolve-String -Text $testItem.Configuration.SubjectGroup) -ErrorAction Stop
 						} -EnableException $EnableException.ToBool() -PSCmdlet $PSCmdlet -Continue

--- a/DomainManagement/functions/system/Reset-DMDomainCredential.ps1
+++ b/DomainManagement/functions/system/Reset-DMDomainCredential.ps1
@@ -28,6 +28,7 @@
 		Clear all cached credentials
 #>
 	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "")]
 	[CmdletBinding()]
 	param (
 		[Parameter(Mandatory = $true, ParameterSetName = 'Credential')]

--- a/DomainManagement/functions/system/Reset-DMDomainCredential.ps1
+++ b/DomainManagement/functions/system/Reset-DMDomainCredential.ps1
@@ -27,6 +27,7 @@
 	
 		Clear all cached credentials
 #>
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
 	[CmdletBinding()]
 	param (
 		[Parameter(Mandatory = $true, ParameterSetName = 'Credential')]

--- a/DomainManagement/functions/system/Reset-DMDomainCredential.ps1
+++ b/DomainManagement/functions/system/Reset-DMDomainCredential.ps1
@@ -1,0 +1,79 @@
+﻿function Reset-DMDomainCredential
+{
+<#
+	.SYNOPSIS
+		Resets cached credentials for contacting domains.
+	
+	.DESCRIPTION
+		Resets cached credentials for contacting domains.
+		Use this command when invalidating credentials you used.
+		For example in ADMF the credential provider:
+		If you create one that uses a temporary account, then delete it when done, you need to reset the cache when connecting with your default credentials.
+	
+	.PARAMETER Credential
+		Clear all cache entries using this credential object.
+	
+	.PARAMETER Domain
+		Clear the cached credentials for the target domain.
+	
+	.PARAMETER UserName
+		Clear all cached credentials using this username.
+	
+	.PARAMETER All
+		Clear ALL cached credentials
+	
+	.EXAMPLE
+		PS C:\> Reset-DMDomainCredential -All
+	
+		Clear all cached credentials
+#>
+	[CmdletBinding()]
+	param (
+		[Parameter(Mandatory = $true, ParameterSetName = 'Credential')]
+		[PSCredential]
+		$Credential,
+		
+		[Parameter(Mandatory = $true, ParameterSetName = 'Domain')]
+		[string]
+		$Domain,
+		
+		[Parameter(Mandatory = $true, ParameterSetName = 'Name')]
+		[string]
+		$UserName,
+		
+		[Parameter(Mandatory = $true, ParameterSetName = 'All')]
+		[switch]
+		$All
+	)
+	
+	process
+	{
+		switch ($PSCmdlet.ParameterSetName)
+		{
+			'Credential'
+			{
+				[string[]]$keys = $script:domainCredentialCache.Keys
+				foreach ($key in $keys)
+				{
+					if ($script:domainCredentialCache[$key] -eq $Credential) { $script:domainCredentialCache.Remove($key) }
+				}
+			}
+			'Domain'
+			{
+				$script:domainCredentialCache.Remove($Domain)
+			}
+			'Name'
+			{
+				[string[]]$keys = $script:domainCredentialCache.Keys
+				foreach ($key in $keys)
+				{
+					if ($script:domainCredentialCache[$key].UserName -eq $UserName) { $script:domainCredentialCache.Remove($key) }
+				}
+			}
+			'All'
+			{
+				$script:domainCredentialCache = @{ }
+			}
+		}
+	}
+}

--- a/DomainManagement/internal/functions/Resolve-ContentSearchBase.ps1
+++ b/DomainManagement/internal/functions/Resolve-ContentSearchBase.ps1
@@ -28,7 +28,7 @@
 		
 		Resolves the configured filters into searchbases for the targeted domain.
 #>
-	
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "")]
     [CmdletBinding()]
     Param (
         [string]

--- a/DomainManagement/internal/functions/acl_ace/Remove-RedundantAce.ps1
+++ b/DomainManagement/internal/functions/acl_ace/Remove-RedundantAce.ps1
@@ -23,6 +23,7 @@
 
         Removes all redundant access rules on $aclobject that apply to $identity.
     #>
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "")]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
     [CmdletBinding()]
     param (

--- a/DomainManagement/internal/functions/groupPolicy/Install-GroupPolicy.ps1
+++ b/DomainManagement/internal/functions/groupPolicy/Install-GroupPolicy.ps1
@@ -24,6 +24,7 @@
 
 		Installs the specified group policy on the remote system connected to via $session.
 	#>
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseUsingScopeModifierInNewRunspaces", "")]
 	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
 	[CmdletBinding()]
 	param (

--- a/DomainManagement/internal/functions/groupPolicy/New-GpoWorkingDirectory.ps1
+++ b/DomainManagement/internal/functions/groupPolicy/New-GpoWorkingDirectory.ps1
@@ -16,6 +16,7 @@
 
 		Ensures the working folder exists and stores the session-local path in the $workingFolder variable.
 	#>
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseUsingScopeModifierInNewRunspaces", "")]
 	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
 	[OutputType([string])]
 	[CmdletBinding()]

--- a/DomainManagement/internal/functions/groupPolicy/Remove-GroupPolicy.ps1
+++ b/DomainManagement/internal/functions/groupPolicy/Remove-GroupPolicy.ps1
@@ -18,6 +18,7 @@
 
 		Removes the specified group policy object.
 	#>
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseUsingScopeModifierInNewRunspaces", "")]
 	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
 	[CmdletBinding()]
 	Param (

--- a/DomainManagement/internal/functions/groupPolicy/Resolve-PolicyRevision.ps1
+++ b/DomainManagement/internal/functions/groupPolicy/Resolve-PolicyRevision.ps1
@@ -22,6 +22,7 @@
 
 		Checks the management state information of the specified policy object.
 	#>
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseUsingScopeModifierInNewRunspaces", "")]
 	[CmdletBinding()]
 	Param (
 		[psobject]


### PR DESCRIPTION
- New: Reset-DMDomainCredential - Resets cached credentials for contacting domains.
- Upd: Component Group Membership - now can define Group Processing Mode, introducing Constrained and Additive Modes to a group's memberships.
- Upd: Component Group Membership - configured names may now include SIDs, such as the SIDs of built-in accounts or groups.
- Fix: Register-DMGroupMembership - explicitly registering empty as $false no longer clears configured settings.
- Fix: Invoke-DMPasswordPolicy - disabled per-item confirmation prompt
- Fix: Invoke-DMOrganizationalUnit - fixed processing order