### PR TITLE
1.4.97

### DIFF
--- a/DomainManagement/DomainManagement.psd1
+++ b/DomainManagement/DomainManagement.psd1
@@ -3,7 +3,7 @@
 	RootModule         = 'DomainManagement.psm1'
 	
 	# Version number of this module.
-	ModuleVersion      = '1.4.85'
+	ModuleVersion      = '1.4.97'
 	
 	# ID used to uniquely identify this module
 	GUID               = '0a405382-ebc2-445b-8325-541535810193'

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -1,6 +1,6 @@
 ﻿# Changelog
 
-## ???
+## 1.4.97 (2020-12-11)
 
 - Upd: Register-DMGroup - added parameter `-Optional` to make a group optional
 - Upd: Renamed test result type `ConfigurationOnly` to `Create`

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -1,14 +1,22 @@
 ﻿# Changelog
 
+## ???
+
+- Upd: Register-DMGroup - added parameter `-Optional` to make a group optional
+- Upd: Renamed test result type `ConfigurationOnly` to `Create`
+- Upd: Test-DMGroup - don't create Create actions for groups that are optional
+- Upd: GPLink - added capability for dynamic path assignments
+- Upd: GPLink - added processing modes to enable adding without removing unknown, as well as explicit delete orders
+- Upd: GPLink - new priority system called tier. This enables grouping GPOs by category in separate priority sets
+- Fix: Test-GPPermission - path-based filters would not correctly map permissions
+- Fix: Component Object - Does not allow modifying properties on the domain object itself
+- Fix: Various - Removed duplicate confirm prompts from several invoke commands
+- Fix: Invoke-DMGPPermission - handled error when identity could not be resolved (e.g. when a group does not exist but has assigned permissions)
+
 ## 1.4.85 (2020-10-11)
 
 - Upd: Removed most dependencies due to bug in PS5.1. Dependencies in ADMF itself are now expected to provide the necessary tools / modules.
 - Upd: Incremented PSFramework minimum version.
-- Upd: Register-DMGroup - added parameter `-Optional` to make a group optional
-- Upd: Renamed test result type `ConfigurationOnly` to `Create`
-- Upd: Test-DMGroup - don't create Create actions for groups that are optional
-- Fix: Test-GPPermission - path-based filters would not correctly map permissions
-- Fix: Component Object - Does not allow modifying properties on the domain object itself
 
 ## 1.4.84 (2020-09-10)
 

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -8,6 +8,8 @@
 - Upd: GPLink - added capability for dynamic path assignments
 - Upd: GPLink - added processing modes to enable adding without removing unknown, as well as explicit delete orders
 - Upd: GPLink - new priority system called tier. This enables grouping GPOs by category in separate priority sets
+- Upd: ACL - added capability to define default ownership of objects under management
+- Upd: ACL - added capability to define ownership and inheritance by object category for objects under management
 - Fix: Test-GPPermission - path-based filters would not correctly map permissions
 - Fix: Component Object - Does not allow modifying properties on the domain object itself
 - Fix: Various - Removed duplicate confirm prompts from several invoke commands

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -4,7 +4,11 @@
 
 - Upd: Removed most dependencies due to bug in PS5.1. Dependencies in ADMF itself are now expected to provide the necessary tools / modules.
 - Upd: Incremented PSFramework minimum version.
+- Upd: Register-DMGroup - added parameter `-Optional` to make a group optional
+- Upd: Renamed test result type `ConfigurationOnly` to `Create`
+- Upd: Test-DMGroup - don't create Create actions for groups that are optional
 - Fix: Test-GPPermission - path-based filters would not correctly map permissions
+- Fix: Component Object - Does not allow modifying properties on the domain object itself
 
 ## 1.4.84 (2020-09-10)
 

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -4,6 +4,7 @@
 
 - Upd: Removed most dependencies due to bug in PS5.1. Dependencies in ADMF itself are now expected to provide the necessary tools / modules.
 - Upd: Incremented PSFramework minimum version.
+- Fix: Test-GPPermission - path-based filters would not correctly map permissions
 
 ## 1.4.84 (2020-09-10)
 

--- a/DomainManagement/en-us/strings.psd1
+++ b/DomainManagement/en-us/strings.psd1
@@ -62,17 +62,13 @@
 	
 	'Invoke-DMDomainLevel.Raise.Level'                              = 'Raising domain level to {0}' # $testItem.Configuration.Level
 	
-	'Invoke-DMGPLink.Delete.AllDisabled'                            = 'Removing all ({0}) policy links (all of which are disabled)' # $countActual
 	'Invoke-DMGPLink.Delete.AllEnabled'                             = 'Removing all ({0}) policy links (all of which are enabled)' # $countActual
-	'Invoke-DMGPLink.Delete.SomeDisabled'                           = 'Removing all ({0}) policy links' # $countActual
 	'Invoke-DMGPLink.New'                                           = 'Linking {0} group policies (all new links)' # $countConfigured
 	'Invoke-DMGPLink.New.GpoNotFound'                               = 'Unable to find Group POlicy Object: {0}' # (Resolve-String -Text $_.PolicyName)
 	'Invoke-DMGPLink.New.NewGPLinkString'                           = 'Finished gPLink string being applied to {0}: {1}' # $ADObject.DistinguishedName, $gpLinkString
-	'Invoke-DMGPLink.Update.AllDisabled'                            = 'Updating GPLink - {0} links configured, {1} links present, {2} links present that are not in configuration (All present and undesired links are disabled)' # $countConfigured, $countActual, $countNotInConfig
 	'Invoke-DMGPLink.Update.AllEnabled'                             = 'Updating GPLink - {0} links configured, {1} links present, {2} links present that are not in configuration (All present and undesired links are enabled)' # $countConfigured, $countActual, $countNotInConfig
 	'Invoke-DMGPLink.Update.GpoNotFound'                            = 'Unable to find Group POlicy Object: {0}' # (Resolve-String -Text $_.PolicyName)
 	'Invoke-DMGPLink.Update.NewGPLinkString'                        = 'Finished gPLink string being applied to {0}: {1}' # $ADObject.DistinguishedName, $gpLinkString
-	'Invoke-DMGPLink.Update.SomeDisabled'                           = 'Updating GPLink - {0} links configured, {1} links present, {2} links present that are not in configuration' # $countConfigured, $countActual, $countNotInConfig
 	
 	'Invoke-DMGPPermission.AD.Access.Error'                         = 'Error accessing Active Directory for {0} ({1})' # $testResult, $testResult.ADObject.DistinguishedName
 	'Invoke-DMGPPermission.AD.UpdatingPermission'                   = 'Updating {0} permission changes on the AD object' # $testResult.Changed.Count

--- a/DomainManagement/en-us/strings.psd1
+++ b/DomainManagement/en-us/strings.psd1
@@ -1,202 +1,203 @@
 ﻿# This is where the strings go, that are written by
 # Write-PSFMessage, Stop-PSFFunction or the PSFramework validation scriptblocks
 @{
-	'Assert-ADConnection.Failed'								    = 'Failed to connect to {0}' # $Server
+	'Assert-ADConnection.Failed'                                    = 'Failed to connect to {0}' # $Server
 	
-	'Assert-Configuration.NotConfigured'						    = 'No configuration data provided for: {0}' # $Type
+	'Assert-Configuration.NotConfigured'                            = 'No configuration data provided for: {0}' # $Type
 	
-	'Convert-AccessRule.Identity.ResolutionError'				    = 'Failed to convert identity. This generally means a configuration error, especially when referencing the parent as identity.' # 
+	'Convert-AccessRule.Identity.ResolutionError'                   = 'Failed to convert identity. This generally means a configuration error, especially when referencing the parent as identity.' # 
 	
-	'Convert-Principal.Processing'								    = 'Converting principal: {0}' # $Name
-	'Convert-Principal.Processing.InputNT'						    = 'Input detected as NT: {0}' # $Name
-	'Convert-Principal.Processing.InputSID'						    = 'Input detected as SID: {0}' # $Name
-	'Convert-Principal.Processing.NT.LdapFilter'				    = 'Resolving NT identity via AD using the following filter: {0}' # "(samAccountName=$namePart)"
-	'Convert-Principal.Processing.NTDetails'					    = 'Resolved NT identity: Domain = {0} | Name = {1}' # $domainPart, $namePart
+	'Convert-Principal.Processing'                                  = 'Converting principal: {0}' # $Name
+	'Convert-Principal.Processing.InputNT'                          = 'Input detected as NT: {0}' # $Name
+	'Convert-Principal.Processing.InputSID'                         = 'Input detected as SID: {0}' # $Name
+	'Convert-Principal.Processing.NT.LdapFilter'                    = 'Resolving NT identity via AD using the following filter: {0}' # "(samAccountName=$namePart)"
+	'Convert-Principal.Processing.NTDetails'                        = 'Resolved NT identity: Domain = {0} | Name = {1}' # $domainPart, $namePart
 	
-	'General.Invalid.Input'										    = 'Invalid input: {1}! This command only accepts output objects from {0}' # 'Test-DMAccessRule', $testItem
+	'General.Invalid.Input'                                         = 'Invalid input: {1}! This command only accepts output objects from {0}' # 'Test-DMAccessRule', $testItem
 	
-	'Get-PermissionGuidMapping.Processing'						    = 'Processing Permission Guids for domain: {0} (This may take a while)' # $identity
+	'Get-PermissionGuidMapping.Processing'                          = 'Processing Permission Guids for domain: {0} (This may take a while)' # $identity
 	
-	'Get-Principal.Resolution.Failed'							    = 'Failed to resolve principal: SID {0} | Name {1} | ObjectClass {2} | Domain {3}' # $Sid, $Name, $ObjectClass, $Domain
+	'Get-Principal.Resolution.Failed'                               = 'Failed to resolve principal: SID {0} | Name {1} | ObjectClass {2} | Domain {3}' # $Sid, $Name, $ObjectClass, $Domain
 	
-	'Get-SchemaGuidMapping.Processing'							    = 'Processing Schema Guids for domain: {0} (This may take a while)' # $identity
+	'Get-SchemaGuidMapping.Processing'                              = 'Processing Schema Guids for domain: {0} (This may take a while)' # $identity
 	
-	'Install-GroupPolicy.CopyingFiles'							    = 'Copying GPO files for "{0}"' # $Configuration.DisplayName
-	'Install-GroupPolicy.CopyingFiles.Failed'					    = 'Failed to copy the GPO files for "{0}"' # $Configuration.DisplayName
-	'Install-GroupPolicy.DeletingImportFiles'					    = 'Deleting the GPO files for "{0}"' # $Configuration.DisplayName
-	'Install-GroupPolicy.Importing.RegistryValues'				    = 'Applying registry settings to GPO "{0}"' # $Configuration.DisplayName
-	'Install-GroupPolicy.Importing.RegistryValues.Failed'		    = 'Failed to apply registry settings to GPO "{0}": {1} --> {2}' # $Configuration.DisplayName, $registryDatum.Key, $registryDatum.ValueName
-	'Install-GroupPolicy.ImportingConfiguration'				    = 'Importing the GPO "{0}" from the defined source files' # $Configuration.DisplayName
-	'Install-GroupPolicy.ImportingConfiguration.Failed'			    = 'Failed to impoter the GPO "{0}"' # $Configuration.DisplayName
-	'Install-GroupPolicy.ReadingADObject'						    = 'Reading the AD object of the imported GPO: "{0}"' # $Configuration.DisplayName
-	'Install-GroupPolicy.ReadingADObject.Failed.Error'			    = 'Failed to access the GPO AD object of "{0}", could not validate creation!' # $Configuration.DisplayName
-	'Install-GroupPolicy.ReadingADObject.Failed.NoObject'		    = 'The AD object for GPO "{0}" cannot be found! Please manually verify succcess and troubleshoot the creation process/environment.' # $Configuration.DisplayName
-	'Install-GroupPolicy.ReadingADObject.Failed.Timestamp'		    = 'Failed to vallidate import of the GPO "{0}". Its last modified timestamp ({1}) is older than the time the import started ({2}). This would usually be the case when the GPO already existed before the process and the import failed for some reason. Please troubleshoot the GPO creation process and the target environment.' # $Configuration.DisplayName, $policyObject.Modified, $timestamp
-	'Install-GroupPolicy.UpdatingConfigurationFile'				    = 'Updating the configuration metadata file for "{0}" on the target domain.' # $Configuration.DisplayName
-	'Install-GroupPolicy.UpdatingConfigurationFile.Failed'		    = 'Failed to update the configuration metadata file for "{0}" on the target domain. This will cause the GPO to not register as managed and will be flagged as to update on the next test. Please validate filesystem write access to the targeted GPO.' # $Configuration.DisplayName
+	'Install-GroupPolicy.CopyingFiles'                              = 'Copying GPO files for "{0}"' # $Configuration.DisplayName
+	'Install-GroupPolicy.CopyingFiles.Failed'                       = 'Failed to copy the GPO files for "{0}"' # $Configuration.DisplayName
+	'Install-GroupPolicy.DeletingImportFiles'                       = 'Deleting the GPO files for "{0}"' # $Configuration.DisplayName
+	'Install-GroupPolicy.Importing.RegistryValues'                  = 'Applying registry settings to GPO "{0}"' # $Configuration.DisplayName
+	'Install-GroupPolicy.Importing.RegistryValues.Failed'           = 'Failed to apply registry settings to GPO "{0}": {1} --> {2}' # $Configuration.DisplayName, $registryDatum.Key, $registryDatum.ValueName
+	'Install-GroupPolicy.ImportingConfiguration'                    = 'Importing the GPO "{0}" from the defined source files' # $Configuration.DisplayName
+	'Install-GroupPolicy.ImportingConfiguration.Failed'             = 'Failed to impoter the GPO "{0}"' # $Configuration.DisplayName
+	'Install-GroupPolicy.ReadingADObject'                           = 'Reading the AD object of the imported GPO: "{0}"' # $Configuration.DisplayName
+	'Install-GroupPolicy.ReadingADObject.Failed.Error'              = 'Failed to access the GPO AD object of "{0}", could not validate creation!' # $Configuration.DisplayName
+	'Install-GroupPolicy.ReadingADObject.Failed.NoObject'           = 'The AD object for GPO "{0}" cannot be found! Please manually verify succcess and troubleshoot the creation process/environment.' # $Configuration.DisplayName
+	'Install-GroupPolicy.ReadingADObject.Failed.Timestamp'          = 'Failed to vallidate import of the GPO "{0}". Its last modified timestamp ({1}) is older than the time the import started ({2}). This would usually be the case when the GPO already existed before the process and the import failed for some reason. Please troubleshoot the GPO creation process and the target environment.' # $Configuration.DisplayName, $policyObject.Modified, $timestamp
+	'Install-GroupPolicy.UpdatingConfigurationFile'                 = 'Updating the configuration metadata file for "{0}" on the target domain.' # $Configuration.DisplayName
+	'Install-GroupPolicy.UpdatingConfigurationFile.Failed'          = 'Failed to update the configuration metadata file for "{0}" on the target domain. This will cause the GPO to not register as managed and will be flagged as to update on the next test. Please validate filesystem write access to the targeted GPO.' # $Configuration.DisplayName
 	
-	'Invoke-Callback.Invoking'									    = 'Executing callback: {0}' # $callback.Name
-	'Invoke-Callback.Invoking.Failed'							    = 'Error executing callback: {0}' # $callback.Name
-	'Invoke-Callback.Invoking.Success'							    = 'Successfully executed callback: {0}' # $callback.Name
+	'Invoke-Callback.Invoking'                                      = 'Executing callback: {0}' # $callback.Name
+	'Invoke-Callback.Invoking.Failed'                               = 'Error executing callback: {0}' # $callback.Name
+	'Invoke-Callback.Invoking.Success'                              = 'Successfully executed callback: {0}' # $callback.Name
 	
-	'Invoke-DMAccessRule.Access.Failed'							    = 'Failed to access ACL on {0}' # $testItem.Identity
-	'Invoke-DMAccessRule.AccessRule.Create'						    = 'Adding access rule for {0}, granting {1} ({2})' # $changeEntry.Configuration.IdentityReference, $changeEntry.Configuration.ActiveDirectoryRights, $changeEntry.Configuration.AccessControlType
-	'Invoke-DMAccessRule.AccessRule.Creation.Failed'			    = 'Failed to create accessrule at {0} for {1}' # $testItem.Identity, $changeEntry.Configuration.IdentityReference
-	'Invoke-DMAccessRule.AccessRule.Remove'						    = 'Removing access rule for {0}, granting {1} ({2})' # $changeEntry.ADObject.IdentityReference, $changeEntry.ADObject.ActiveDirectoryRights, $changeEntry.ADObject.AccessControlType
-	'Invoke-DMAccessRule.AccessRule.Remove.Failed'				    = 'Failed to removing access rule for {0}, granting {1} ({2}) for unknown reasons (sorry)' # $changeEntry.ADObject.IdentityReference, $changeEntry.ADObject.ActiveDirectoryRights, $changeEntry.ADObject.AccessControlType
-	'Invoke-DMAccessRule.ADObject.Missing'						    = 'Cannot process access rules, due to missing AD object: {0}. Please ensure the domain object is created before trying to apply rules to it!' # $testItem.Identity
-	'Invoke-DMAccessRule.Processing.Execute'					    = 'Applying {0} out of {1} intended access rule changes' # ($testItem.Changed.Count - $failedCount), $testItem.Changed.Count
-	'Invoke-DMAccessRule.Processing.Rules'						    = 'Processing {1} access rule changes on {0}' # $testItem.Identity, $testItem.Changed.Count
+	'Invoke-DMAccessRule.Access.Failed'                             = 'Failed to access ACL on {0}' # $testItem.Identity
+	'Invoke-DMAccessRule.AccessRule.Create'                         = 'Adding access rule for {0}, granting {1} ({2})' # $changeEntry.Configuration.IdentityReference, $changeEntry.Configuration.ActiveDirectoryRights, $changeEntry.Configuration.AccessControlType
+	'Invoke-DMAccessRule.AccessRule.Creation.Failed'                = 'Failed to create accessrule at {0} for {1}' # $testItem.Identity, $changeEntry.Configuration.IdentityReference
+	'Invoke-DMAccessRule.AccessRule.Remove'                         = 'Removing access rule for {0}, granting {1} ({2})' # $changeEntry.ADObject.IdentityReference, $changeEntry.ADObject.ActiveDirectoryRights, $changeEntry.ADObject.AccessControlType
+	'Invoke-DMAccessRule.AccessRule.Remove.Failed'                  = 'Failed to removing access rule for {0}, granting {1} ({2}) for unknown reasons (sorry)' # $changeEntry.ADObject.IdentityReference, $changeEntry.ADObject.ActiveDirectoryRights, $changeEntry.ADObject.AccessControlType
+	'Invoke-DMAccessRule.ADObject.Missing'                          = 'Cannot process access rules, due to missing AD object: {0}. Please ensure the domain object is created before trying to apply rules to it!' # $testItem.Identity
+	'Invoke-DMAccessRule.Processing.Execute'                        = 'Applying {0} out of {1} intended access rule changes' # ($testItem.Changed.Count - $failedCount), $testItem.Changed.Count
+	'Invoke-DMAccessRule.Processing.Rules'                          = 'Processing {1} access rule changes on {0}' # $testItem.Identity, $testItem.Changed.Count
 	
-	'Invoke-DMAcl.MissingADObject'								    = 'The target object could not be found: {0}' # $testItem.Identity
-	'Invoke-DMAcl.NoAccess'										    = 'Failed to access Acl on {0}' # $testItem.Identity
-	'Invoke-DMAcl.OwnerNotResolved'								    = 'Was unable to resolve the current owner ({1}) of {0}' # $testItem.Identity, $testItem.ADObject.GetOwner([System.Security.Principal.SecurityIdentifier])
-	'Invoke-DMAcl.ShouldManage'									    = 'The ADObject {0} has no defined ACL state and should either be configured or removed' # $testItem.Identity
-	'Invoke-DMAcl.UpdatingInheritance'							    = 'Updating inheritance - Inheritance Disabled: {0}' # $testItem.Configuration.NoInheritance
-	'Invoke-DMAcl.UpdatingOwner'								    = 'Granting ownership to {0}' # ($testItem.Configuration.Owner | Resolve-String)
+	'Invoke-DMAcl.MissingADObject'                                  = 'The target object could not be found: {0}' # $testItem.Identity
+	'Invoke-DMAcl.NoAccess'                                         = 'Failed to access Acl on {0}' # $testItem.Identity
+	'Invoke-DMAcl.OwnerNotResolved'                                 = 'Was unable to resolve the current owner ({1}) of {0}' # $testItem.Identity, $testItem.ADObject.GetOwner([System.Security.Principal.SecurityIdentifier])
+	'Invoke-DMAcl.ShouldManage'                                     = 'The ADObject {0} has no defined ACL state and should either be configured or removed' # $testItem.Identity
+	'Invoke-DMAcl.UpdatingInheritance'                              = 'Updating inheritance - Inheritance Disabled: {0}' # $testItem.Configuration.NoInheritance
+	'Invoke-DMAcl.UpdatingOwner'                                    = 'Granting ownership to {0}' # ($testItem.Configuration.Owner | Resolve-String)
 	
-	'Invoke-DMDomainData.Invocation.Error'						    = 'An exception was thrown while executing the domain data script "{0}".' # $Name
-	'Invoke-DMDomainData.Invocation.Error.Terminate'			    = 'Critical Error: An exception was thrown while executing the domain data script "{0}".' # $Name
-	'Invoke-DMDomainData.Script.NotFound'						    = 'Could not find a registered DomainData set with the name "{0}". Be sure to register an appropriate configuration and check for typos.' # $Name
-	'Invoke-DMDomainData.Script.NotFound.Error'					    = 'Critical error: Could not find a registered DomainData set with the name "{0}". Be sure to register an appropriate configuration and check for typos.' # $Name
+	'Invoke-DMDomainData.Invocation.Error'                          = 'An exception was thrown while executing the domain data script "{0}".' # $Name
+	'Invoke-DMDomainData.Invocation.Error.Terminate'                = 'Critical Error: An exception was thrown while executing the domain data script "{0}".' # $Name
+	'Invoke-DMDomainData.Script.NotFound'                           = 'Could not find a registered DomainData set with the name "{0}". Be sure to register an appropriate configuration and check for typos.' # $Name
+	'Invoke-DMDomainData.Script.NotFound.Error'                     = 'Critical error: Could not find a registered DomainData set with the name "{0}". Be sure to register an appropriate configuration and check for typos.' # $Name
 	
-	'Invoke-DMDomainLevel.Raise.Level'							    = 'Raising domain level to {0}' # $testItem.Configuration.Level
+	'Invoke-DMDomainLevel.Raise.Level'                              = 'Raising domain level to {0}' # $testItem.Configuration.Level
 	
-	'Invoke-DMGPLink.Delete.AllDisabled'						    = 'Removing all ({0}) policy links (all of which are disabled)' # $countActual
-	'Invoke-DMGPLink.Delete.AllEnabled'							    = 'Removing all ({0}) policy links (all of which are enabled)' # $countActual
-	'Invoke-DMGPLink.Delete.SomeDisabled'						    = 'Removing all ({0}) policy links' # $countActual
-	'Invoke-DMGPLink.New'										    = 'Linking {0} group policies (all new links)' # $countConfigured
-	'Invoke-DMGPLink.New.GpoNotFound'							    = 'Unable to find Group POlicy Object: {0}' # (Resolve-String -Text $_.PolicyName)
-	'Invoke-DMGPLink.New.NewGPLinkString'						    = 'Finished gPLink string being applied to {0}: {1}' # $ADObject.DistinguishedName, $gpLinkString
-	'Invoke-DMGPLink.Update.AllDisabled'						    = 'Updating GPLink - {0} links configured, {1} links present, {2} links present that are not in configuration (All present and undesired links are disabled)' # $countConfigured, $countActual, $countNotInConfig
-	'Invoke-DMGPLink.Update.AllEnabled'							    = 'Updating GPLink - {0} links configured, {1} links present, {2} links present that are not in configuration (All present and undesired links are enabled)' # $countConfigured, $countActual, $countNotInConfig
-	'Invoke-DMGPLink.Update.GpoNotFound'						    = 'Unable to find Group POlicy Object: {0}' # (Resolve-String -Text $_.PolicyName)
-	'Invoke-DMGPLink.Update.NewGPLinkString'					    = 'Finished gPLink string being applied to {0}: {1}' # $ADObject.DistinguishedName, $gpLinkString
-	'Invoke-DMGPLink.Update.SomeDisabled'						    = 'Updating GPLink - {0} links configured, {1} links present, {2} links present that are not in configuration' # $countConfigured, $countActual, $countNotInConfig
+	'Invoke-DMGPLink.Delete.AllDisabled'                            = 'Removing all ({0}) policy links (all of which are disabled)' # $countActual
+	'Invoke-DMGPLink.Delete.AllEnabled'                             = 'Removing all ({0}) policy links (all of which are enabled)' # $countActual
+	'Invoke-DMGPLink.Delete.SomeDisabled'                           = 'Removing all ({0}) policy links' # $countActual
+	'Invoke-DMGPLink.New'                                           = 'Linking {0} group policies (all new links)' # $countConfigured
+	'Invoke-DMGPLink.New.GpoNotFound'                               = 'Unable to find Group POlicy Object: {0}' # (Resolve-String -Text $_.PolicyName)
+	'Invoke-DMGPLink.New.NewGPLinkString'                           = 'Finished gPLink string being applied to {0}: {1}' # $ADObject.DistinguishedName, $gpLinkString
+	'Invoke-DMGPLink.Update.AllDisabled'                            = 'Updating GPLink - {0} links configured, {1} links present, {2} links present that are not in configuration (All present and undesired links are disabled)' # $countConfigured, $countActual, $countNotInConfig
+	'Invoke-DMGPLink.Update.AllEnabled'                             = 'Updating GPLink - {0} links configured, {1} links present, {2} links present that are not in configuration (All present and undesired links are enabled)' # $countConfigured, $countActual, $countNotInConfig
+	'Invoke-DMGPLink.Update.GpoNotFound'                            = 'Unable to find Group POlicy Object: {0}' # (Resolve-String -Text $_.PolicyName)
+	'Invoke-DMGPLink.Update.NewGPLinkString'                        = 'Finished gPLink string being applied to {0}: {1}' # $ADObject.DistinguishedName, $gpLinkString
+	'Invoke-DMGPLink.Update.SomeDisabled'                           = 'Updating GPLink - {0} links configured, {1} links present, {2} links present that are not in configuration' # $countConfigured, $countActual, $countNotInConfig
 	
-	'Invoke-DMGPPermission.AD.Access.Error'						    = 'Error accessing Active Directory for {0} ({1})' # $testResult, $testResult.ADObject.DistinguishedName
-	'Invoke-DMGPPermission.AD.UpdatingPermission'				    = 'Updating {0} permission changes on the AD object' # $testResult.Changed.Count
-	'Invoke-DMGPPermission.Gpo.SyncingPermission'				    = 'Making {0} permission changes consistent through the GPO Api' # $testResult.Changed.Count
-	'Invoke-DMGPPermission.Invalid.Input'						    = 'The input object was not recognized as a valid test result for Group Policy Permissions: {0}' # $testResult
-	'Invoke-DMGPPermission.Result.Access.Error'					    = 'The test for {0} failed, due to access error during the test phase!' # $testResult.Identity
-	'Invoke-DMGPPermission.WinRM.Failed'						    = 'Failed to connect to {0}' # $computerName
+	'Invoke-DMGPPermission.AD.Access.Error'                         = 'Error accessing Active Directory for {0} ({1})' # $testResult, $testResult.ADObject.DistinguishedName
+	'Invoke-DMGPPermission.AD.UpdatingPermission'                   = 'Updating {0} permission changes on the AD object' # $testResult.Changed.Count
+	'Invoke-DMGPPermission.Gpo.SyncingPermission'                   = 'Making {0} permission changes consistent through the GPO Api' # $testResult.Changed.Count
+	'Invoke-DMGPPermission.Invalid.Input'                           = 'The input object was not recognized as a valid test result for Group Policy Permissions: {0}' # $testResult
+	'Invoke-DMGPPermission.Result.Access.Error'                     = 'The test for {0} failed, due to access error during the test phase!' # $testResult.Identity
+	'Invoke-DMGPPermission.WinRM.Failed'                            = 'Failed to connect to {0}' # $computerName
+	'Invoke-DMGPPermission.AccessRule.Error'                        = 'Error creating accessrule for identity "{0}" of principal "{1}". Make sure the principal exists' # $change.Identity, $change.DisplayName
 	
-	'Invoke-DMGroup.Group.Create'								    = 'Creating active directory group' # 
-	'Invoke-DMGroup.Group.Create.OUExistsNot'					    = 'Cannot create group {1} : Path does not exist: {0}' # $targetOU, $testItem.Identity
-	'Invoke-DMGroup.Group.Delete'								    = 'Deleting active directory group' # 
-	'Invoke-DMGroup.Group.InvalidScope'							    = 'Invalid scope defined for {0}: {1} is not a legal group scope.' # $testItem, $targetScope
-	'Invoke-DMGroup.Group.Move'									    = 'Moving active directory group to {0}' # $targetOU
-	'Invoke-DMGroup.Group.MultipleOldGroups'					    = 'Cannot rename group to {0}: More than one group exists owning one of the previous names. Conflicting groups: {1}. Please investigate and manually resolve.' # $testItem.Identity, ($testItem.ADObject.Name -join ', ')
-	'Invoke-DMGroup.Group.Rename'								    = 'Renaming active directory group to {0}' # (Resolve-String -Text $testItem.Configuration.Name)
-	'Invoke-DMGroup.Group.Update'								    = 'Updating {0} on active directory group' # ($changes.Keys -join ", ")
-	'Invoke-DMGroup.Group.Update.Name'							    = 'Renaming to {0}' # (Resolve-String -Text $testItem.Configuration.Name)
-	'Invoke-DMGroup.Group.Update.OUExistsNot'					    = 'Cannot move active directory group {0} - OU does not exist: {1}' # $testItem.Identity, $targetOU
-	'Invoke-DMGroup.Group.Update.Scope'							    = 'Updating the group scope of {0} from {1} to {2}' # $testItem, $testItem.ADObject.GroupScope, $targetScope
+	'Invoke-DMGroup.Group.Create'                                   = 'Creating active directory group' # 
+	'Invoke-DMGroup.Group.Create.OUExistsNot'                       = 'Cannot create group {1} : Path does not exist: {0}' # $targetOU, $testItem.Identity
+	'Invoke-DMGroup.Group.Delete'                                   = 'Deleting active directory group' # 
+	'Invoke-DMGroup.Group.InvalidScope'                             = 'Invalid scope defined for {0}: {1} is not a legal group scope.' # $testItem, $targetScope
+	'Invoke-DMGroup.Group.Move'                                     = 'Moving active directory group to {0}' # $targetOU
+	'Invoke-DMGroup.Group.MultipleOldGroups'                        = 'Cannot rename group to {0}: More than one group exists owning one of the previous names. Conflicting groups: {1}. Please investigate and manually resolve.' # $testItem.Identity, ($testItem.ADObject.Name -join ', ')
+	'Invoke-DMGroup.Group.Rename'                                   = 'Renaming active directory group to {0}' # (Resolve-String -Text $testItem.Configuration.Name)
+	'Invoke-DMGroup.Group.Update'                                   = 'Updating {0} on active directory group' # ($changes.Keys -join ", ")
+	'Invoke-DMGroup.Group.Update.Name'                              = 'Renaming to {0}' # (Resolve-String -Text $testItem.Configuration.Name)
+	'Invoke-DMGroup.Group.Update.OUExistsNot'                       = 'Cannot move active directory group {0} - OU does not exist: {1}' # $testItem.Identity, $targetOU
+	'Invoke-DMGroup.Group.Update.Scope'                             = 'Updating the group scope of {0} from {1} to {2}' # $testItem, $testItem.ADObject.GroupScope, $targetScope
 	
-	'Invoke-DMGroupMembership.GroupMember.Add'					    = 'Adding member to {0}' # $testItem.ADObject.Name
-	'Invoke-DMGroupMembership.GroupMember.Remove'				    = 'Removing member from {0}' # $testItem.ADObject.Name
-	'Invoke-DMGroupMembership.GroupMember.RemoveUnidentified'	    = 'Removing unidentified foreign security principal from {0}' # $testItem.ADObject.Name
-	'Invoke-DMGroupMembership.Unidentified'						    = 'Could not identify current group member: {0}' # $testItem.Identity
-	'Invoke-DMGroupMembership.Unresolved'						    = 'Could not identify required group member: {0}' # $testItem.Identity
+	'Invoke-DMGroupMembership.GroupMember.Add'                      = 'Adding member to {0}' # $testItem.ADObject.Name
+	'Invoke-DMGroupMembership.GroupMember.Remove'                   = 'Removing member from {0}' # $testItem.ADObject.Name
+	'Invoke-DMGroupMembership.GroupMember.RemoveUnidentified'       = 'Removing unidentified foreign security principal from {0}' # $testItem.ADObject.Name
+	'Invoke-DMGroupMembership.Unidentified'                         = 'Could not identify current group member: {0}' # $testItem.Identity
+	'Invoke-DMGroupMembership.Unresolved'                           = 'Could not identify required group member: {0}' # $testItem.Identity
 	
-	'Invoke-DMGroupPolicy.Delete'								    = 'Deleting group policy object: {0}.' # $testItem.Identity
-	'Invoke-DMGroupPolicy.Install.OnBadRegistry'				    = 'Re-applying GPO "{0}" after detecting a registry setting that is not as defined.' # $testItem.Identity
-	'Invoke-DMGroupPolicy.Install.OnConfigError'				    = 'Re-applying GPO "{0}" after failing to read its configuration' # $testItem.Identity
-	'Invoke-DMGroupPolicy.Install.OnManage'						    = 'Re-Applying GPO "{0}" for the first time to bring it under management' # $testItem.Identity
-	'Invoke-DMGroupPolicy.Install.OnModify'						    = 'GPO "{0}" was modified outside this system, re-applying GPO' # $testItem.Identity
-	'Invoke-DMGroupPolicy.Install.OnNew'						    = 'GPO "{0}" not found in AD, creating new GPO' # $testItem.Identity
-	'Invoke-DMGroupPolicy.Install.OnUpdate'						    = 'New GPO definition available, updating GPO "{0}"' # $testItem.Identity
-	'Invoke-DMGroupPolicy.Remote.WorkingDirectory.Failed'		    = 'Failed to create working directory on {0}. This is required for importing GPOs' # $computerName
-	'Invoke-DMGroupPolicy.Skipping.InCriticalState'				    = 'Critical error validating {0}. The GPO will be skipped, please manually verify the GPO and bring it into a supportable state.' # $testItem.Identity
-	'Invoke-DMGroupPolicy.WinRM.Failed'							    = 'Failed to connect to "{0}" via WinRM/PowerShell Remoting.' # $computerName
+	'Invoke-DMGroupPolicy.Delete'                                   = 'Deleting group policy object: {0}.' # $testItem.Identity
+	'Invoke-DMGroupPolicy.Install.OnBadRegistry'                    = 'Re-applying GPO "{0}" after detecting a registry setting that is not as defined.' # $testItem.Identity
+	'Invoke-DMGroupPolicy.Install.OnConfigError'                    = 'Re-applying GPO "{0}" after failing to read its configuration' # $testItem.Identity
+	'Invoke-DMGroupPolicy.Install.OnManage'                         = 'Re-Applying GPO "{0}" for the first time to bring it under management' # $testItem.Identity
+	'Invoke-DMGroupPolicy.Install.OnModify'                         = 'GPO "{0}" was modified outside this system, re-applying GPO' # $testItem.Identity
+	'Invoke-DMGroupPolicy.Install.OnNew'                            = 'GPO "{0}" not found in AD, creating new GPO' # $testItem.Identity
+	'Invoke-DMGroupPolicy.Install.OnUpdate'                         = 'New GPO definition available, updating GPO "{0}"' # $testItem.Identity
+	'Invoke-DMGroupPolicy.Remote.WorkingDirectory.Failed'           = 'Failed to create working directory on {0}. This is required for importing GPOs' # $computerName
+	'Invoke-DMGroupPolicy.Skipping.InCriticalState'                 = 'Critical error validating {0}. The GPO will be skipped, please manually verify the GPO and bring it into a supportable state.' # $testItem.Identity
+	'Invoke-DMGroupPolicy.WinRM.Failed'                             = 'Failed to connect to "{0}" via WinRM/PowerShell Remoting.' # $computerName
 	
-	'Invoke-DMObject.Object.Change'								    = 'Updating the properties {0}' # ($testItem.Changed -join ", ")
-	'Invoke-DMObject.Object.Create'								    = 'Creating {0} object in {1}' # $testItem.Configuration.ObjectClass, $testItem.Identity
+	'Invoke-DMObject.Object.Change'                                 = 'Updating the properties {0}' # ($testItem.Changed -join ", ")
+	'Invoke-DMObject.Object.Create'                                 = 'Creating {0} object in {1}' # $testItem.Configuration.ObjectClass, $testItem.Identity
 	
-	'Invoke-DMOrganizationalUnit.OU.Create'						    = 'Creating organizational unit' # 
-	'Invoke-DMOrganizationalUnit.OU.Create.OUExistsNot'			    = 'Cannot create OU {1}, parent OU does not exist: {0}' # $targetOU, $testItem.Identity
-	'Invoke-DMOrganizationalUnit.OU.Delete'						    = 'Deleting organizational unit' # 
-	'Invoke-DMOrganizationalUnit.OU.Delete.HasChildren'			    = 'Skipping the deletion of {0} - OU has {1} childitem(s) that would also be deleted. Please manually handle these before proceeding.' # $testItem.ADObject.DistinguishedName, ($childObjects | Measure-Object).Count
-	'Invoke-DMOrganizationalUnit.OU.Delete.NoAction'			    = 'Skipping the deletion of {0} - OU deletion has been disabled' # $testItem.Identity
-	'Invoke-DMOrganizationalUnit.OU.MultipleOldOUs'				    = 'Cannot rename organizational unit to {0}: More than one organizational unit exists owning one of the previous names. Conflicting organizational unit: {1}. Please investigate and manually resolve.' # $testItem.Identity, ($testItem.ADObject.Name -join ', ')
-	'Invoke-DMOrganizationalUnit.OU.Rename'						    = 'Renaming organizational unit to {0}' # (Resolve-String -Text $testItem.Configuration.Name)
-	'Invoke-DMOrganizationalUnit.OU.Update'						    = 'Updating {0} on organizational unit' # ($changes.Keys -join ", ")
+	'Invoke-DMOrganizationalUnit.OU.Create'                         = 'Creating organizational unit' # 
+	'Invoke-DMOrganizationalUnit.OU.Create.OUExistsNot'             = 'Cannot create OU {1}, parent OU does not exist: {0}' # $targetOU, $testItem.Identity
+	'Invoke-DMOrganizationalUnit.OU.Delete'                         = 'Deleting organizational unit' # 
+	'Invoke-DMOrganizationalUnit.OU.Delete.HasChildren'             = 'Skipping the deletion of {0} - OU has {1} childitem(s) that would also be deleted. Please manually handle these before proceeding.' # $testItem.ADObject.DistinguishedName, ($childObjects | Measure-Object).Count
+	'Invoke-DMOrganizationalUnit.OU.Delete.NoAction'                = 'Skipping the deletion of {0} - OU deletion has been disabled' # $testItem.Identity
+	'Invoke-DMOrganizationalUnit.OU.MultipleOldOUs'                 = 'Cannot rename organizational unit to {0}: More than one organizational unit exists owning one of the previous names. Conflicting organizational unit: {1}. Please investigate and manually resolve.' # $testItem.Identity, ($testItem.ADObject.Name -join ', ')
+	'Invoke-DMOrganizationalUnit.OU.Rename'                         = 'Renaming organizational unit to {0}' # (Resolve-String -Text $testItem.Configuration.Name)
+	'Invoke-DMOrganizationalUnit.OU.Update'                         = 'Updating {0} on organizational unit' # ($changes.Keys -join ", ")
 	
-	'Invoke-DMPasswordPolicy.PSO.Create'						    = 'Creating new PSO object' # 
-	'Invoke-DMPasswordPolicy.PSO.Delete'						    = 'Deleting PSO object' # 
-	'Invoke-DMPasswordPolicy.PSO.Update'						    = 'Updating properties: {0}' # ($changes.Keys -join ", ")
-	'Invoke-DMPasswordPolicy.PSO.Update.GroupAssignment'		    = 'Assigning PSO to {0}' # (Resolve-String -Text $testItem.Configuration.SubjectGroup)
+	'Invoke-DMPasswordPolicy.PSO.Create'                            = 'Creating new PSO object' # 
+	'Invoke-DMPasswordPolicy.PSO.Delete'                            = 'Deleting PSO object' # 
+	'Invoke-DMPasswordPolicy.PSO.Update'                            = 'Updating properties: {0}' # ($changes.Keys -join ", ")
+	'Invoke-DMPasswordPolicy.PSO.Update.GroupAssignment'            = 'Assigning PSO to {0}' # (Resolve-String -Text $testItem.Configuration.SubjectGroup)
 	
-	'Invoke-DMUser.User.Create'									    = 'Creating active directory user' # 
-	'Invoke-DMUser.User.Create.OUExistsNot'						    = 'Cannot create user {1} : Path does not exist: {0}' # $targetOU, $testItem.Identity
-	'Invoke-DMUser.User.Delete'									    = 'Deleting active directory user' # 
-	'Invoke-DMUser.User.Move'									    = 'Moving active directory user to {0}' # $targetOU
-	'Invoke-DMUser.User.MultipleOldUsers'						    = 'Cannot rename user to {0}: More than one user exists owning one of the previous names. Conflicting users: {1}. Please investigate and manually resolve.' # $testItem.Identity, ($testItem.ADObject.Name -join ', ')
-	'Invoke-DMUser.User.Rename'									    = 'Renaming active directory user to {0}' # (Resolve-String -Text $testItem.Configuration.SamAccountName)
-	'Invoke-DMUser.User.Update'									    = 'Updating {0} on active directory user' # ($changes.Keys -join ", ")
-	'Invoke-DMUser.User.Update.EnableDisable'					    = 'Changing user enabled state to: {0}' # $testItem.Configuration.Enabled
-	'Invoke-DMUser.User.Update.Name'							    = 'Renaming user to {0}' # (Resolve-String -Text $testItem.Configuration.Name)
-	'Invoke-DMUser.User.Update.OUExistsNot'						    = 'Cannot move active directory group {0} - user does not exist: {1}' # $testItem.Identity, $targetOU
-	'Invoke-DMUser.User.Update.PasswordNeverExpires'			    = 'Changing user password non-expiration to: {0}' # $testItem.Configuration.PasswordNeverExpires
+	'Invoke-DMUser.User.Create'                                     = 'Creating active directory user' # 
+	'Invoke-DMUser.User.Create.OUExistsNot'                         = 'Cannot create user {1} : Path does not exist: {0}' # $targetOU, $testItem.Identity
+	'Invoke-DMUser.User.Delete'                                     = 'Deleting active directory user' # 
+	'Invoke-DMUser.User.Move'                                       = 'Moving active directory user to {0}' # $targetOU
+	'Invoke-DMUser.User.MultipleOldUsers'                           = 'Cannot rename user to {0}: More than one user exists owning one of the previous names. Conflicting users: {1}. Please investigate and manually resolve.' # $testItem.Identity, ($testItem.ADObject.Name -join ', ')
+	'Invoke-DMUser.User.Rename'                                     = 'Renaming active directory user to {0}' # (Resolve-String -Text $testItem.Configuration.SamAccountName)
+	'Invoke-DMUser.User.Update'                                     = 'Updating {0} on active directory user' # ($changes.Keys -join ", ")
+	'Invoke-DMUser.User.Update.EnableDisable'                       = 'Changing user enabled state to: {0}' # $testItem.Configuration.Enabled
+	'Invoke-DMUser.User.Update.Name'                                = 'Renaming user to {0}' # (Resolve-String -Text $testItem.Configuration.Name)
+	'Invoke-DMUser.User.Update.OUExistsNot'                         = 'Cannot move active directory group {0} - user does not exist: {1}' # $testItem.Identity, $targetOU
+	'Invoke-DMUser.User.Update.PasswordNeverExpires'                = 'Changing user password non-expiration to: {0}' # $testItem.Configuration.PasswordNeverExpires
 	
-	'Remove-GroupPolicy.Deleting'								    = 'Deleting GPO: {0}' # $ADObject.DisplayName
-	'Remove-GroupPolicy.Deleting.Failed'						    = 'Failed to delete GPO: {0}' # $ADObject.DisplayName
+	'Remove-GroupPolicy.Deleting'                                   = 'Deleting GPO: {0}' # $ADObject.DisplayName
+	'Remove-GroupPolicy.Deleting.Failed'                            = 'Failed to delete GPO: {0}' # $ADObject.DisplayName
 	
-	'Resolve-ContentSearchBase.Exclude.NotFound'				    = 'Failed to find excluded ou/container: {0}' # $item.Name
-	'Resolve-ContentSearchBase.Include.NotFound'				    = 'Failed to find included ou/container: {0}' # $item.Name
-	'Resolve-ContentSearchBase.Searchbase.Found'				    = 'Resolved searchbase in {2}: {0} | {1}' # $searchBase.SearchScope, $searchBase.SearchBase, $script:domainContext.Fqdn
+	'Resolve-ContentSearchBase.Exclude.NotFound'                    = 'Failed to find excluded ou/container: {0}' # $item.Name
+	'Resolve-ContentSearchBase.Include.NotFound'                    = 'Failed to find included ou/container: {0}' # $item.Name
+	'Resolve-ContentSearchBase.Searchbase.Found'                    = 'Resolved searchbase in {2}: {0} | {1}' # $searchBase.SearchScope, $searchBase.SearchBase, $script:domainContext.Fqdn
 	
-	'Resolve-DMAccessRuleMode.PathResolution.Failed'			    = 'Unable to resolve path: {0}' # $mode.Path
+	'Resolve-DMAccessRuleMode.PathResolution.Failed'                = 'Unable to resolve path: {0}' # $mode.Path
 	
-	'Resolve-Identity.ParentObject.NoSecurityPrincipal'			    = 'Error processing parent of {0} : {1} of type {2} is no legal security principal and cannot be assigned permissions!' # $ADObject, $parentObject.Name, $parentObject.ObjectClass
+	'Resolve-Identity.ParentObject.NoSecurityPrincipal'             = 'Error processing parent of {0} : {1} of type {2} is no legal security principal and cannot be assigned permissions!' # $ADObject, $parentObject.Name, $parentObject.ObjectClass
 	
-	'Resolve-PolicyRevision.Result.ErrorOnConfigImport'			    = 'Failed to read configuration for {0}: {1}' # $Policy.DisplayName, $result.Error.Exception.Message
-	'Resolve-PolicyRevision.Result.PolicyError'					    = 'Policy object not found in filesystem: {0}. Check existence and permissions!' # $Policy.DisplayName
-	'Resolve-PolicyRevision.Result.Result.SuccessNotYetManaged'	    = 'Policy found: {0}. Has not yet been managed, will need to be overwritten.' # $Policy.DisplayName
-	'Resolve-PolicyRevision.Result.Success'						    = 'Found GPO: {0}. Last export ID: {1}. Last updated on {2}' # $Policy.DisplayName, $result.ExportID, $result.Timestamp
+	'Resolve-PolicyRevision.Result.ErrorOnConfigImport'             = 'Failed to read configuration for {0}: {1}' # $Policy.DisplayName, $result.Error.Exception.Message
+	'Resolve-PolicyRevision.Result.PolicyError'                     = 'Policy object not found in filesystem: {0}. Check existence and permissions!' # $Policy.DisplayName
+	'Resolve-PolicyRevision.Result.Result.SuccessNotYetManaged'     = 'Policy found: {0}. Has not yet been managed, will need to be overwritten.' # $Policy.DisplayName
+	'Resolve-PolicyRevision.Result.Success'                         = 'Found GPO: {0}. Last export ID: {1}. Last updated on {2}' # $Policy.DisplayName, $result.ExportID, $result.Timestamp
 	
-	'Set-DMRedForestContext.Connection.Failed'					    = 'Failed to connect to {0}' # $Server
+	'Set-DMRedForestContext.Connection.Failed'                      = 'Failed to connect to {0}' # $Server
 	
-	'Test-DMAccessRule.DefaultPermission.Failed'				    = 'Failed to retrieve default permissions from Schema when connecting to {0}' # $Server
-	'Test-DMAccessRule.NoAccess'								    = 'Failed to access {0}' # $resolvedPath
+	'Test-DMAccessRule.DefaultPermission.Failed'                    = 'Failed to retrieve default permissions from Schema when connecting to {0}' # $Server
+	'Test-DMAccessRule.NoAccess'                                    = 'Failed to access {0}' # $resolvedPath
 	
-	'Test-DMAcl.ADObjectNotFound'								    = 'The target object could not be found: {0}' # $resolvedPath
-	'Test-DMAcl.NoAccess'										    = 'Failed to access Acl on {0}' # $resolvedPath
+	'Test-DMAcl.ADObjectNotFound'                                   = 'The target object could not be found: {0}' # $resolvedPath
+	'Test-DMAcl.NoAccess'                                           = 'Failed to access Acl on {0}' # $resolvedPath
 	
-	'Test-DMGPLink.OUNotFound'									    = 'Failed to find the configured OU: {0} - Please validate your OU configuration and bring your OU estate into the desired state first!' # $resolvedName
+	'Test-DMGPLink.OUNotFound'                                      = 'Failed to find the configured OU: {0} - Please validate your OU configuration and bring your OU estate into the desired state first!' # $resolvedName
 	
 	'Test-DMGPPermission.Filter.Path.DoesNotExist.SilentlyContinue' = 'The searchbase for the filter condition {0} could not be found. This however was defined as optional and is not an error: {1}' # $Condition.Name, $searchBase
-	'Test-DMGPPermission.Filter.Path.DoesNotExist.Stop'			    = 'The searchbase {1} for the filter condition {0} could not be found. A consistent picture of the desired permission configuration is impossible, terminating!' # $searchBase
-	'Test-DMGPPermission.Filter.Result'							    = 'Resolved filter condition {0} to GPOs: {1}' # $key, ($filterToGPOMapping[$key].DisplayName -join ', ')
-	'Test-DMGPPermission.Identity.Resolution.Error'				    = 'Failed to resolve the identity of an intended privilege-holder on {0}. Cancelling the processing for this GPO, as correct access configuration is not assured.' # $adObject.DisplayName
-	'Test-DMGPPermission.Validate.MissingFilterConditions'		    = 'Critical configuration error: Not all referenced Group Policy Permission filter-conditions were defined. Undefined conditions: {0}' # ($missingConditions -join ", ")
-	'Test-DMGPPermission.WinRM.Failed'							    = 'Failed to connect to {0}' # $computerName
+	'Test-DMGPPermission.Filter.Path.DoesNotExist.Stop'             = 'The searchbase {1} for the filter condition {0} could not be found. A consistent picture of the desired permission configuration is impossible, terminating!' # $searchBase
+	'Test-DMGPPermission.Filter.Result'                             = 'Resolved filter condition {0} to GPOs: {1}' # $key, ($filterToGPOMapping[$key].DisplayName -join ', ')
+	'Test-DMGPPermission.Identity.Resolution.Error'                 = 'Failed to resolve the identity of an intended privilege-holder on {0}. Cancelling the processing for this GPO, as correct access configuration is not assured.' # $adObject.DisplayName
+	'Test-DMGPPermission.Validate.MissingFilterConditions'          = 'Critical configuration error: Not all referenced Group Policy Permission filter-conditions were defined. Undefined conditions: {0}' # ($missingConditions -join ", ")
+	'Test-DMGPPermission.WinRM.Failed'                              = 'Failed to connect to {0}' # $computerName
 	
-	'Test-DMGPRegistrySetting.TestResult'						    = 'Finished testing GP Registry settings against {0}. Success: {1} | Status: {2}' # $resolvedName, $result.Success, $result.Status
-	'Test-DMGPRegistrySetting.WinRM.Failed'						    = 'Failed to connect to {0}' # $parameters.Server
+	'Test-DMGPRegistrySetting.TestResult'                           = 'Finished testing GP Registry settings against {0}. Success: {1} | Status: {2}' # $resolvedName, $result.Success, $result.Status
+	'Test-DMGPRegistrySetting.WinRM.Failed'                         = 'Failed to connect to {0}' # $parameters.Server
 	
-	'Test-DMGroupMembership.Assignment.Resolve.Connect'			    = 'Failed to resolve {2} {1} - Could not connect to {0}' # (Resolve-String -Text $assignment.Domain), (Resolve-String -Text $assignment.Name), $assignment.ItemType
-	'Test-DMGroupMembership.Assignment.Resolve.NotFound'		    = 'Successfully queried domain "{0}", but the member {1} of type {2} could not be found' # (Resolve-String -Text $assignment.Domain), (Resolve-String -Text $assignment.Name), $assignment.ItemType
-	'Test-DMGroupMembership.Group.Access.Failed'				    = 'Failed to access group {0} in target domain, cannot compare its members with the configured state.' # $resolvedGroupName
+	'Test-DMGroupMembership.Assignment.Resolve.Connect'             = 'Failed to resolve {2} {1} - Could not connect to {0}' # (Resolve-String -Text $assignment.Domain), (Resolve-String -Text $assignment.Name), $assignment.ItemType
+	'Test-DMGroupMembership.Assignment.Resolve.NotFound'            = 'Successfully queried domain "{0}", but the member {1} of type {2} could not be found' # (Resolve-String -Text $assignment.Domain), (Resolve-String -Text $assignment.Name), $assignment.ItemType
+	'Test-DMGroupMembership.Group.Access.Failed'                    = 'Failed to access group {0} in target domain, cannot compare its members with the configured state.' # $resolvedGroupName
 	
-	'Test-DMGroupPolicy.ADObjectAccess.Failed'					    = 'Failed to access GPO active directory object for: {0}' # $managedPolicy.DistinguishedName
-	'Test-DMGroupPolicy.DomainData.Failed'						    = 'Failed to retrieve the domain-specific data for the following sources: {0}' # ($domainDataNames -join ",")
-	'Test-DMGroupPolicy.PolicyRevision.Lookup.Failed'			    = 'Failed to resolve GPO in AD: {0}' # $managedPolicies.DisplayName
-	'Test-DMGroupPolicy.WinRM.Failed'							    = 'Failed to connect to "{0}" via WinRM/PowerShell Remoting.' # $computerName
+	'Test-DMGroupPolicy.ADObjectAccess.Failed'                      = 'Failed to access GPO active directory object for: {0}' # $managedPolicy.DistinguishedName
+	'Test-DMGroupPolicy.DomainData.Failed'                          = 'Failed to retrieve the domain-specific data for the following sources: {0}' # ($domainDataNames -join ",")
+	'Test-DMGroupPolicy.PolicyRevision.Lookup.Failed'               = 'Failed to resolve GPO in AD: {0}' # $managedPolicies.DisplayName
+	'Test-DMGroupPolicy.WinRM.Failed'                               = 'Failed to connect to "{0}" via WinRM/PowerShell Remoting.' # $computerName
 	
-	'Test-DMObject.ADObject.Access.Error'						    = 'Failed to access {0} while retrieving {1}' # $resolvedPath, ($objectDefinition.Attributes.Keys -join ",")
-	'Test-DMObject.ADObject.Access.Error2'						    = 'Failed to access {0}' # $resolvedPath
+	'Test-DMObject.ADObject.Access.Error'                           = 'Failed to access {0} while retrieving {1}' # $resolvedPath, ($objectDefinition.Attributes.Keys -join ",")
+	'Test-DMObject.ADObject.Access.Error2'                          = 'Failed to access {0}' # $resolvedPath
 	
-	'Test-DMPasswordPolicy.SubjectGroup.NotFound'				    = 'Failed to find the group {0}, which should be granted permission to the Finegrained Password Policy {1}' # $groupName, $resolvedName
+	'Test-DMPasswordPolicy.SubjectGroup.NotFound'                   = 'Failed to find the group {0}, which should be granted permission to the Finegrained Password Policy {1}' # $groupName, $resolvedName
 	
-	'Validate.DomainData.Pattern'								    = 'Invalid input: {0}. A domain data name must only consist of numbers, letters and underscore.' # <user input>, <validation item>
-	'Validate.GPPermissionFilter'								    = 'Invalid GP Permission filter: {0}' # <user input>, <validation item>
-	'Validate.GPPermissionFilter.InvalidIdentifiers'			    = 'Invalid filter elements (filter names): {1}. Filters can only consist of letters, numbers and underscore. Filter: {0}' # $_, ($invalidIdentifiers -join ', ')
-	'Validate.GPPermissionFilter.InvalidParameters'				    = 'Invalid filter elements (parameters): {1}. Only the four basic logical parameters are allowed: -and, -or, -not, -xor! Filter: {0}' # $_, ($invalidParameters -join ', ')
-	'Validate.GPPermissionFilter.InvalidTokenType'				    = 'Invalid filter element types: {1}. Only parenthesis, filter names and logical operators are allowed! Filter: {0}' # $_, ($invalidTokenTypes -join ', ')
-	'Validate.GPPermissionFilter.SyntaxError'					    = 'General syntax error in your filter string: {0}' # $_
-	'Validate.Identity'											    = 'Invalid identity: {0} - Either specify a SID, a name in the format "<domain>\<name>" or in the format "<name>@<domainfqdn>"' # <user input>, <validation item>
-	'Validate.Name.Pattern'										    = 'Invalid input: {0}. The name tag must start with a "%", end in a "%" and contain only letters, underscore and numbers inbetween.' # <user input>, <validation item>
-	'Validate.PermissionFilterName'								    = 'Invalid input: {0}. GP Permission Filter names may only consist of letters, numbers and underscore characters.' # <user input>, <validation item>
-	'Validate.TypeName.AccessRule.Failed'						    = 'The input object {0} could not be verified as a "DomainManagement.AccessRule" object.' # <user input>, <validation item>
+	'Validate.DomainData.Pattern'                                   = 'Invalid input: {0}. A domain data name must only consist of numbers, letters and underscore.' # <user input>, <validation item>
+	'Validate.GPPermissionFilter'                                   = 'Invalid GP Permission filter: {0}' # <user input>, <validation item>
+	'Validate.GPPermissionFilter.InvalidIdentifiers'                = 'Invalid filter elements (filter names): {1}. Filters can only consist of letters, numbers and underscore. Filter: {0}' # $_, ($invalidIdentifiers -join ', ')
+	'Validate.GPPermissionFilter.InvalidParameters'                 = 'Invalid filter elements (parameters): {1}. Only the four basic logical parameters are allowed: -and, -or, -not, -xor! Filter: {0}' # $_, ($invalidParameters -join ', ')
+	'Validate.GPPermissionFilter.InvalidTokenType'                  = 'Invalid filter element types: {1}. Only parenthesis, filter names and logical operators are allowed! Filter: {0}' # $_, ($invalidTokenTypes -join ', ')
+	'Validate.GPPermissionFilter.SyntaxError'                       = 'General syntax error in your filter string: {0}' # $_
+	'Validate.Identity'                                             = 'Invalid identity: {0} - Either specify a SID, a name in the format "<domain>\<name>" or in the format "<name>@<domainfqdn>"' # <user input>, <validation item>
+	'Validate.Name.Pattern'                                         = 'Invalid input: {0}. The name tag must start with a "%", end in a "%" and contain only letters, underscore and numbers inbetween.' # <user input>, <validation item>
+	'Validate.PermissionFilterName'                                 = 'Invalid input: {0}. GP Permission Filter names may only consist of letters, numbers and underscore characters.' # <user input>, <validation item>
+	'Validate.TypeName.AccessRule.Failed'                           = 'The input object {0} could not be verified as a "DomainManagement.AccessRule" object.' # <user input>, <validation item>
 }

--- a/DomainManagement/functions/acls/Get-DMAcl.ps1
+++ b/DomainManagement/functions/acls/Get-DMAcl.ps1
@@ -24,6 +24,8 @@
 	
 	process
 	{
-		($script:acls.Values | Where-Object Path -like $Path)
+		($script:acls.Values) | Where-Object Path -like $Path
+		($script:aclsByCategory.Values) | Where-Object Category -like $Path
+		$script:aclDefaultOwner | Where-Object Path -like $Path
 	}
 }

--- a/DomainManagement/functions/acls/Invoke-DMAcl.ps1
+++ b/DomainManagement/functions/acls/Invoke-DMAcl.ps1
@@ -58,7 +58,7 @@
 		$parameters['Debug'] = $false
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
-		Assert-Configuration -Type Acls -Cmdlet $PSCmdlet
+		Assert-Configuration -Type Acls, AclByCategory, AclDefaultOwner -Cmdlet $PSCmdlet
 		Set-DMDomainContext @parameters
 	}
 	process{

--- a/DomainManagement/functions/acls/Register-DMAcl.ps1
+++ b/DomainManagement/functions/acls/Register-DMAcl.ps1
@@ -24,6 +24,14 @@
 		The path this acl object is assigned to is optional and need not exist.
 		This makes the rule apply only if the object exists, without triggering errors if it doesn't.
 		It will also ignore access errors on the object.
+
+	.PARAMETER DefaultOwner
+		Whether to make this the default owner for objects not specified under either a path or an object category.
+
+	.PARAMETER ContextName
+		The name of the context defining the setting.
+		This allows determining the configuration set that provided this setting.
+		Used by the ADMF, available to any other configuration management solution.
 	
 	.EXAMPLE
 		PS C:\> Get-Content .\groups.json | ConvertFrom-Json | Write-Output | Register-DMAcl
@@ -31,32 +39,74 @@
 		Reads a json configuration file containing a list of objects with appropriate properties to import them as acl configuration.
 	#>
 	
-	[CmdletBinding()]
+	[CmdletBinding(DefaultParameterSetName = 'path')]
 	param (
-		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'path')]
 		[string]
 		$Path,
+
+		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'category')]
+		[string]
+		$ObjectCategory,
 
 		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
 		[string]
 		$Owner,
 
-		[Parameter(ValueFromPipelineByPropertyName = $true)]
+		[Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'path')]
+		[Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'category')]
 		[bool]
 		$NoInheritance = $false,
 
-		[Parameter(ValueFromPipelineByPropertyName = $true)]
+		[Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'path')]
+		[Parameter(ValueFromPipelineByPropertyName = $true, ParameterSetName = 'category')]
 		[bool]
-		$Optional = $false
+		$Optional = $false,
+
+		[Parameter(ParameterSetName = 'DefaultOwner')]
+		[switch]
+		$DefaultOwner,
+
+		[string]
+		$ContextName = '<Undefined>'
 	)
 	process
 	{
-		$script:acls[$Path] = [PSCustomObject]@{
-			PSTypeName = 'DomainManagement.Acl'
-			Path = $Path
-			Owner = $Owner
-			NoInheritance = $NoInheritance
-			Optional = $Optional
+		switch ($PSCmdlet.ParameterSetName) {
+			'path'
+			{
+				$script:acls[$Path] = [PSCustomObject]@{
+					PSTypeName = 'DomainManagement.Acl'
+					Path = $Path
+					Owner = $Owner
+					NoInheritance = $NoInheritance
+					Optional = $Optional
+					ContextName = $ContextName
+				}
+			}
+			'category'
+			{
+				$script:aclByCategory[$ObjectCategory] = [PSCustomObject]@{
+					PSTypeName = 'DomainManagement.Acl'
+					Category = $ObjectCategory
+					Owner = $Owner
+					NoInheritance = $NoInheritance
+					Optional = $Optional
+					ContextName = $ContextName
+				}
+			}
+			'DefaultOwner'
+			{
+				# Array to appease Assert-Configuration
+				$script:aclDefaultOwner = @([PSCustomObject]@{
+					PSTypeName = 'DomainManagement.Acl'
+					Path = '<default>'
+					Owner = $Owner
+					NoInheritance = $false
+					Optional = $null
+					ContextName = $ContextName
+				})
+			}
 		}
 	}
 }

--- a/DomainManagement/functions/acls/Register-DMAcl.ps1
+++ b/DomainManagement/functions/acls/Register-DMAcl.ps1
@@ -11,6 +11,9 @@
 	.PARAMETER Path
 		Path (distinguishedName) of the ADObject the acl is assigned to.
 		Subject to string insertion.
+
+	.PARAMETER ObjectCategory
+		Assign ACL settings based on the ObjectCategory of an object.
 	
 	.PARAMETER Owner
 		Owner of the ADObject.
@@ -38,7 +41,7 @@
 
 		Reads a json configuration file containing a list of objects with appropriate properties to import them as acl configuration.
 	#>
-	
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '')]
 	[CmdletBinding(DefaultParameterSetName = 'path')]
 	param (
 		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'path')]

--- a/DomainManagement/functions/acls/Test-DMAcl.ps1
+++ b/DomainManagement/functions/acls/Test-DMAcl.ps1
@@ -63,17 +63,6 @@
 				New-TestResult @resultDefaults -Identity $ADObject -Configuration $Category -Type Changed -Changed $changes.ToArray() -ADObject $aclObject
 			}
 		}
-
-		function Get-ChangeByGlobalDefault {
-			[CmdletBinding()]
-			param (
-				$ADObject,
-
-				$ResultDefaults,
-
-				$Parameters
-			)
-		}
 		#endregion Functions
 	}
 	process

--- a/DomainManagement/functions/acls/Unregister-DMAcl.ps1
+++ b/DomainManagement/functions/acls/Unregister-DMAcl.ps1
@@ -9,6 +9,9 @@
 	
 	.PARAMETER Path
 		The path (distinguishedName) of the acl to remove.
+
+	.PARAMETER Category
+		The object category the acl settings apply to
 	
 	.EXAMPLE
 		PS C:\> Get-DMAcl | Unregister-DMAcl
@@ -20,13 +23,21 @@
 	param (
 		[Parameter(ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
 		[string[]]
-		$Path
+		$Path,
+
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
+		[string[]]
+		$Category
 	)
 	
 	process
 	{
 		foreach ($pathItem in $Path) {
-			$script:acls.Remove($pathItem)
+			if ($pathItem -eq '<default>') { $script:aclDefaultOwner = $null }
+			else { $script:acls.Remove($pathItem) }
+		}
+		foreach ($categoryItem in $Category) {
+			$script:aclByCategory.Remove($categoryItem)
 		}
 	}
 }

--- a/DomainManagement/functions/gplinks/Get-DMGPLink.ps1
+++ b/DomainManagement/functions/gplinks/Get-DMGPLink.ps1
@@ -31,8 +31,11 @@
 	
 	process
 	{
-		($script:groupPolicyLinks.Values.Values | Where-Object {
+		($script:groupPolicyLinks.Values.Values) | Where-Object {
 			($_.PolicyName -like $PolicyName) -and ($_.OrganizationalUnit -like $OrganizationalUnit)
-		})
+		}
+		($script:groupPolicyLinksDynamic.Values.Values) | Where-Object {
+			($_.PolicyName -like $PolicyName) -and ($_.OrganizationalUnit -like $OrganizationalUnit)
+		}
 	}
 }

--- a/DomainManagement/functions/gplinks/Register-DMGPLink.ps1
+++ b/DomainManagement/functions/gplinks/Register-DMGPLink.ps1
@@ -1,5 +1,4 @@
-﻿function Register-DMGPLink
-{
+﻿function Register-DMGPLink {
 	<#
 	.SYNOPSIS
 		Registers a group policy link as a desired state.
@@ -14,10 +13,34 @@
 	.PARAMETER OrganizationalUnit
 		The organizational unit (or domain root) being linked to.
 		Supports string expansion.
+
+	.PARAMETER OUFilter
+		A filter string for an organizational unit.
+		The filter must be a wildcard-pattern supporting distinguishedname.
 	
 	.PARAMETER Precedence
 		Numeric value representing the order it is linked in.
 		The lower the number, the higher on the list, the more relevant the setting.
+
+	.PARAMETER Tier
+		The tier of a link is a priority ordering on top of Precedence.
+		While precedence determines order within a given tier, each tier is processed separately.
+		The higher the tier number, the higher the priority.
+		In additive mode, already existing linked policies have a Tier 0 priority.
+		If you want your own policies to be prepended, use Tier 1 or higher.
+		If you want your own policies to have the least priority however, user Tier -1 or lower.
+		Default: 1
+
+	.PARAMETER ProcessingMode
+		In which way GPO links are being processed:
+		- Additive: Add provided links, but do not modify the existing ones.
+		- Constrained: Replace existing links that are undesired
+		By default, constrained mode is being used.
+		If any single link for a given Organizational Unit is in constrained mode, the entire OU is processed under constraind mode.
+
+	.PARAMETER Present
+		Whether the link should be present at all.
+		Relevant in additive mode, to retain the capability to delete undesired links.
 	
 	.EXAMPLE
 		PS C:\> Get-Content $configPath | ConvertFrom-Json | Write-Output | Register-DMGPLink
@@ -30,26 +53,63 @@
 		[string]
 		$PolicyName,
 
-		[parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+		[parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Path')]
 		[Alias('OU')]
 		[string]
 		$OrganizationalUnit,
 
+		[parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Filter')]
+		[string]
+		$OUFilter,
+
 		[parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
 		[int]
-		$Precedence
+		$Precedence,
+
+		[parameter(ValueFromPipelineByPropertyName = $true)]
+		[int]
+		$Tier = 1,
+
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
+		[ValidateSet('Constrained', 'Additive')]
+		[string]
+		$ProcessingMode = 'Constrained',
+
+		[parameter(ValueFromPipelineByPropertyName = $true)]
+		[bool]
+		$Present = $true
 	)
 	
-	process
-	{
-		if (-not $script:groupPolicyLinks[$OrganizationalUnit]) {
-			$script:groupPolicyLinks[$OrganizationalUnit] = @{ }
-		}
-		$script:groupPolicyLinks[$OrganizationalUnit][$PolicyName] = [PSCustomObject]@{
-			PSTypeName = 'DomainManagement.GPLink'
-			PolicyName = $PolicyName
-			OrganizationalUnit = $OrganizationalUnit
-			Precedence = $Precedence
+	process {
+		switch ($PSCmdlet.ParameterSetName) {
+			'Path' {
+				if (-not $script:groupPolicyLinks[$OrganizationalUnit]) {
+					$script:groupPolicyLinks[$OrganizationalUnit] = @{ }
+				}
+				$script:groupPolicyLinks[$OrganizationalUnit][$PolicyName] = [PSCustomObject]@{
+					PSTypeName         = 'DomainManagement.GPLink'
+					PolicyName         = $PolicyName
+					OrganizationalUnit = $OrganizationalUnit
+					Precedence         = $Precedence
+					Tier               = $Tier
+					ProcessingMode     = $ProcessingMode
+					Present            = $Present
+				}
+			}
+			'Filter' {
+				if (-not $script:groupPolicyLinksDynamic[$OUFilter]) {
+					$script:groupPolicyLinksDynamic[$OUFilter] = @{ }
+				}
+				$script:groupPolicyLinksDynamic[$OUFilter][$PolicyName] = [PSCustomObject]@{
+					PSTypeName     = 'DomainManagement.GPLink'
+					PolicyName     = $PolicyName
+					OUFilter       = $OUFilter
+					Precedence     = $Precedence
+					Tier           = $Tier
+					ProcessingMode = $ProcessingMode
+					Present        = $Present
+				}
+			}
 		}
 	}
 }

--- a/DomainManagement/functions/gplinks/Test-DMGPLink.ps1
+++ b/DomainManagement/functions/gplinks/Test-DMGPLink.ps1
@@ -48,7 +48,7 @@
 				$resolvedOU = Resolve-String -Text $organizationalUnit
 				$ous[$resolvedOU] = [PSCustomObject]@{
 					OrganizationalUnit = $resolvedOU
-					ProcessingMode     = 'Additive'	
+					ProcessingMode     = 'Additive'
 					Include            = @()
 					Exclude            = @()
 					ExtendedInclude    = @()
@@ -70,7 +70,7 @@
 					if (-not $ous[$adObject.DistinguishedName]) {
 						$ous[$adObject.DistinguishedName] = [PSCustomObject]@{
 							OrganizationalUnit = $adObject.DistinguishedName
-							ProcessingMode     = 'Additive'	
+							ProcessingMode     = 'Additive'
 							Include            = @()
 							Exclude            = @()
 							ExtendedInclude    = @()
@@ -90,6 +90,7 @@
 		}
 		
 		function New-Update {
+			[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
 			[CmdletBinding()]
 			param (
 				$PolicyName,

--- a/DomainManagement/functions/gplinks/Test-DMGPLink.ps1
+++ b/DomainManagement/functions/gplinks/Test-DMGPLink.ps1
@@ -1,5 +1,4 @@
-﻿function Test-DMGPLink
-{
+﻿function Test-DMGPLink {
 	<#
 	.SYNOPSIS
 		Tests, whether the configured group policy linking matches the desired state.
@@ -28,103 +27,196 @@
 		$Credential
 	)
 	
-	begin
-	{
+	begin {
 		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
 		$parameters['Debug'] = $false
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
-		Assert-Configuration -Type GroupPolicyLinks -Cmdlet $PSCmdlet
+		Assert-Configuration -Type GroupPolicyLinks, GroupPolicyLinksDynamic -Cmdlet $PSCmdlet
 		Set-DMDomainContext @parameters
-	}
-	process
-	{
+
+		#region Utility Functions
+		function Get-OUData {
+			[CmdletBinding()]
+			param (
+				$Parameters
+			)
+
+			$ous = @{ }
+			#region Explicit OUs
+			foreach ($organizationalUnit in $script:groupPolicyLinks.Keys) {
+				$resolvedOU = Resolve-String -Text $organizationalUnit
+				$ous[$resolvedOU] = [PSCustomObject]@{
+					OrganizationalUnit = $resolvedOU
+					ProcessingMode     = 'Additive'	
+					Include            = @()
+					Exclude            = @()
+					ExtendedInclude    = @()
+				}
+				$ous[$resolvedOU].Include = $script:groupPolicyLinks[$organizationalUnit].Values | Where-Object Present
+				$ous[$resolvedOU].Exclude = $script:groupPolicyLinks[$organizationalUnit].Values | Where-Object Present -EQ $false
+				if ($ous[$resolvedOU].Include.ProcessingMode -contains 'Constrained') {
+					$ous[$resolvedOU].ProcessingMode = 'Constrained'
+				}
+			}
+			#region Explicit OUs
+			
+			#region Filter-Based OUs
+			foreach ($filter in $script:groupPolicyLinksDynamic.Keys) {
+				$adObjects = Resolve-ADObject @Parameters -Filter (Resolve-String -Text $filter) -ObjectClass organizationalUnit
+				$values = $script:groupPolicyLinksDynamic[$filter].Values
+				
+				foreach ($adObject in $adObjects) {
+					if (-not $ous[$adObject.DistinguishedName]) {
+						$ous[$adObject.DistinguishedName] = [PSCustomObject]@{
+							OrganizationalUnit = $adObject.DistinguishedName
+							ProcessingMode     = 'Additive'	
+							Include            = @()
+							Exclude            = @()
+							ExtendedInclude    = @()
+						}
+					}
+					$container = $ous[$adObject.DistinguishedName]
+					$container.Include = $container.Include, $values | Remove-PSFNull -Enumerate | Where-Object Present
+					$container.Exclude = $container.Exclude, $values | Remove-PSFNull -Enumerate | Where-Object Present -EQ $false
+					if ($container.Include.ProcessingMode -contains 'Constrained') {
+						$container.ProcessingMode = 'Constrained'
+					}
+				}
+			}
+			#endregion Filter-Based OUs
+			
+			$ous.Values
+		}
+		
+		function New-Update {
+			[CmdletBinding()]
+			param (
+				$PolicyName,
+				$Status,
+				$Action
+			)
+
+			[PSCustomObject]@{
+				PSTypeName = 'DomainManagement.GPLink.Update'
+				Action     = $Action
+				Policy     = $PolicyName
+				Status     = $Status
+			}
+		}
+		
+		function Get-LinkUpdate {
+			[CmdletBinding()]
+			param (
+				$Configuration,
+				$ADObject
+			)
+
+			$includeSorted = $Configuration.Include | Sort-Object @{ Expression = { $_.Tier }; Descending = $true }, Precedence | Where-Object PolicyName -NotIn $Configuration.Exclude.PolicyName
+			$currentSorted = $ADObject.LinkedGroupPolicyObjects | Sort-Object Precedence
+
+			if ($Configuration.ProcessingMode -eq 'Additive') {
+				$currentAdditive = $ADObject.LinkedGroupPolicyObjects | Where-Object DisplayName -NotIn $includeSorted.PolicyName | Where-Object DisplayName -NotIn $Configuration.Exclude.PolicyName | Sort-Object Precedence | Add-Member -MemberType NoteProperty -Name Tier -Value 0 -PassThru -Force | Add-Member -MemberType AliasProperty -Name PolicyName -Value DisplayName -PassThru -Force
+				$newDesiredState = @($currentAdditive) + @($includeSorted) | Write-Output | Remove-PSFNull | Sort-Object @{ Expression = { $_.Tier }; Descending = $true }, Precedence
+			}
+			else { $newDesiredState = $includeSorted }
+			$Configuration.ExtendedInclude = $newDesiredState
+				
+			if (Compare-Array -ReferenceObject $newDesiredState.PolicyName -DifferenceObject $currentSorted.DisplayName -OrderSpecific -Quiet) {
+				return
+			}
+
+			$index = 0
+			foreach ($desired in $newDesiredState) {
+				if ($currentSorted.DisplayName -notcontains $desired.PolicyName) {
+					New-Update -Action Add -PolicyName $desired.PolicyName -Status 'Enabled'
+					$index = $index + 1
+					continue
+				}
+				if ($index -gt @($currentSorted).Count -or $desired.PolicyName -ne $currentSorted[$index].DisplayName) {
+					New-Update -Action Reorder -PolicyName $desired.PolicyName -Status 'Enabled'
+					$index = $index + 1
+					continue
+				}
+				$index = $index + 1
+			}
+			foreach ($current in $currentSorted) {
+				if ($current.DisplayName -notin $newDesiredState.PolicyName) {
+					New-Update -Action Delete -PolicyName $current.DisplayName -Status $current.Status
+				}
+			}
+		}
+		#endregion Utility Functions
+
 		$gpoDisplayToDN = @{ }
 		$gpoDNToDisplay = @{ }
 		foreach ($adPolicyObject in (Get-ADObject @parameters -LDAPFilter '(objectCategory=groupPolicyContainer)' -Properties DisplayName, DistinguishedName)) {
 			$gpoDisplayToDN[$adPolicyObject.DisplayName] = $adPolicyObject.DistinguishedName
 			$gpoDNToDisplay[$adPolicyObject.DistinguishedName] = $adPolicyObject.DisplayName
 		}
-
+	}
+	process {
 		#region Process Configuration
-		foreach ($organizationalUnit in $script:groupPolicyLinks.Keys) {
-			$resolvedName = Resolve-String -Text $organizationalUnit
-			$desiredState = $script:groupPolicyLinks[$organizationalUnit].Values
-
+		$ouData = Get-OUData -Parameters $parameters
+		foreach ($ouDatum in $ouData) {
 			$resultDefaults = @{
-				Server = $Server
-				ObjectType = 'GPLink'
-				Identity = $resolvedName
-				Configuration = $desiredState
+				Server        = $Server
+				ObjectType    = 'GPLink'
+				Identity      = $ouDatum.OrganizationalUnit
+				Configuration = $ouDatum
 			}
-			
+
+			#region Handle AD Object doesn't exist
 			try {
-				$adObject = Get-ADObject @parameters -Identity $resolvedName -ErrorAction Stop -Properties gPLink, Name, DistinguishedName
+				$adObject = Get-ADObject @parameters -Identity $ouDatum.OrganizationalUnit -ErrorAction Stop -Properties gPLink, Name, DistinguishedName
 				$resultDefaults['ADObject'] = $adObject
 			}
 			catch {
-				Write-PSFMessage -String 'Test-DMGPLink.OUNotFound' -StringValues $resolvedName -ErrorRecord $_ -Tag 'panic','failed'
+				Write-PSFMessage -String 'Test-DMGPLink.OUNotFound' -StringValues $ouDatum.OrganizationalUnit -ErrorRecord $_ -Tag 'panic', 'failed'
 				New-TestResult @resultDefaults -Type 'MissingParent'
 				Continue
 			}
+			#endregion Handle AD Object doesn't exist
 
+			#region Handle AD Object does not contain any links
 			$currentState = $adObject | ConvertTo-GPLink -PolicyMapping $gpoDNToDisplay
 			Add-Member -InputObject $adObject -MemberType NoteProperty -Name LinkedGroupPolicyObjects -Value $currentState -Force
 			if (-not $currentState) {
 				New-TestResult @resultDefaults -Type 'New'
-					continue
-			}
-
-			$currentStateFilteredSorted = $currentState | Where-Object Status -ne 'Disabled' | Sort-Object Precedence
-			$currentStateSorted = $currentState | Sort-Object Precedence
-			$desiredStateSorted = $desiredState | Sort-Object Precedence
-
-			if (Compare-Array -ReferenceObject $currentStateFilteredSorted.DisplayName -DifferenceObject ($desiredStateSorted.PolicyName | Resolve-String) -Quiet -OrderSpecific) {
-				if (Compare-Array -ReferenceObject $currentStateSorted.DisplayName -DifferenceObject ($desiredStateSorted.PolicyName | Resolve-String) -Quiet -OrderSpecific) { continue }
-				else {
-					New-TestResult @resultDefaults -Type 'UpdateDisabledOnly' -Changed ($currentStateSorted | Where-Object DisplayName -notin $desiredStateSorted.PolicyName)
-					continue
-				}
-			}
-
-			if ($currentStateSorted | Where-Object Status -eq 'Disabled') {
-				New-TestResult @resultDefaults -Type 'UpdateSomeDisabled' -Changed ($currentStateSorted | Where-Object DisplayName -notin $desiredStateSorted.PolicyName)
 				continue
 			}
+			#endregion Handle AD Object does not contain any links
 
-			New-TestResult @resultDefaults -Type 'Update' -Changed ($currentStateSorted | Where-Object DisplayName -notin $desiredStateSorted.PolicyName)
+			$updates = Get-LinkUpdate -Configuration $ouDatum -ADObject $adObject
+			if ($updates) {
+				New-TestResult @resultDefaults -Type 'Update' -Changed $updates
+			}
 		}
-		#endregion Process Configuration
 
 		#region Process Managed Estate
 		# OneLevel needs to be converted to base, as searching for OUs with "OneLevel" would return unmanaged OUs.
 		# This search however is targeted at GPOs linked to managed OUs only.
 		$translateScope = @{
-			'Subtree' = 'Subtree'
+			'Subtree'  = 'Subtree'
 			'OneLevel' = 'Base'
-			'Base' = 'Base'
+			'Base'     = 'Base'
 		}
-		$configuredContainers = $script:groupPolicyLinks.Keys | Resolve-String
 		$adObjects = foreach ($searchBase in (Resolve-ContentSearchBase @parameters)) {
 			Get-ADObject @parameters -LDAPFilter '(gPLink=*)' -SearchBase $searchBase.SearchBase -SearchScope $translateScope[$searchBase.SearchScope] -Properties gPLink, Name, DistinguishedName
 		}
 
 		foreach ($adObject in $adObjects) {
 			# If we have a configuration on it, it has already been processed
-			if ($adObject.DistinguishedName -in $configuredContainers) { continue }
+			if ($adObject.DistinguishedName -in $ouData.OrganizationalUnit) { continue }
 			if ([string]::IsNullOrWhiteSpace($adObject.GPLink)) { continue }
 
 			$linkObjects = $adObject | ConvertTo-GPLink -PolicyMapping $gpoDNToDisplay
 			Add-Member -InputObject $adObject -MemberType NoteProperty -Name LinkedGroupPolicyObjects -Value $linkObjects -Force
-			if (-not ($linkObjects | Where-Object Status -eq Enabled)) {
-				New-TestResult -ObjectType GPLink -Type 'DeleteDisabledOnly' -Identity $adObject.DistinguishedName -Server $Server -ADObject $adObject
-				continue
+
+			$changes = foreach ($linkedObject in $linkObjects) {
+				New-Update -PolicyName $linkedObject.DisplayName -Status $linkedObject.Status -Action Delete
 			}
-			elseif (-not ($linkObjects | Where-Object Status -eq Disabled)) {
-				New-TestResult -ObjectType GPLink -Type 'Delete' -Identity $adObject.DistinguishedName -Server $Server -ADObject $adObject
-				continue
-			}
-			New-TestResult -ObjectType GPLink -Type 'DeleteSomeDisabled' -Identity $adObject.DistinguishedName -Server $Server -ADObject $adObject
+			New-TestResult -ObjectType GPLink -Type 'Delete' -Identity $adObject.DistinguishedName -Server $Server -ADObject $adObject -Changed $changes
 		}
 		#endregion Process Managed Estate
 	}

--- a/DomainManagement/functions/gppermissions/Invoke-DMGPPermission.ps1
+++ b/DomainManagement/functions/gppermissions/Invoke-DMGPPermission.ps1
@@ -177,7 +177,10 @@
 								$_.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier]).ToString() -eq $change.Identity
 							} | ForEach-Object { $null = $acl.RemoveAccessRule($_) }
 						}
-						$accessRulesToAdd = ConvertTo-ADAccessRule -ChangeEntry $change
+						try { $accessRulesToAdd = ConvertTo-ADAccessRule -ChangeEntry $change }
+						catch {
+							Stop-PSFFunction -String 'Invoke-DMGPPermission.AccessRule.Error' -StringValues $change.Identity, $change.DisplayName -ErrorRecord $_ -Continue -EnableException $EnableException -Cmdlet $PSCmdlet
+						}
 						foreach ($rule in $accessRulesToAdd) { $null = $acl.AddAccessRule($rule) }
 					}
 					#endregion Add

--- a/DomainManagement/functions/gppermissions/Test-DMGPPermission.ps1
+++ b/DomainManagement/functions/gppermissions/Test-DMGPPermission.ps1
@@ -213,7 +213,7 @@
 							return
 						}
 
-						$objects = Get-ADObject @parameters -SearchBase $searchBase -SearchScope $condition.Scope -LDAPFilter '(|(objectCategory=OrganizationalUnit)(objectCategory=domainDNS))'
+						$objects = Get-ADObject @parameters -SearchBase $searchBase -SearchScope $condition.Scope -LDAPFilter '(|(objectCategory=OrganizationalUnit)(objectCategory=domainDNS))' -Properties gPLink
 						$allLinkedGpoDNs = $objects | ConvertTo-GPLink | Select-Object -ExpandProperty DistinguishedName -Unique
 						if ($condition.Reverse) { $filterToGPOMapping[$condition.Name] = $allGpos | Where-Object DistinguishedName -notin $allLinkedGpoDNs }
 						else { $filterToGPOMapping[$condition.Name] = $allGpos | Where-Object DistinguishedName -in $allLinkedGpoDNs }

--- a/DomainManagement/functions/groups/Invoke-DMGroup.ps1
+++ b/DomainManagement/functions/groups/Invoke-DMGroup.ps1
@@ -92,9 +92,9 @@
                 }
                 'Rename' {
                     Invoke-PSFProtectedCommand -ActionString 'Invoke-DMGroup.Group.Rename' -ActionStringValues (Resolve-String -Text $testItem.Configuration.Name) -Target $testItem -ScriptBlock {
-						Set-ADGroup @parameters -Identity $testItem.ADObject.ObjectGUID -SamAccountName (Resolve-String -Text $testItem.Configuration.SamAccountName) -ErrorAction Stop
+						Set-ADGroup @parameters -Identity $testItem.ADObject.ObjectGUID -SamAccountName (Resolve-String -Text $testItem.Configuration.SamAccountName) -ErrorAction Stop -Confirm:$false
 						if ((Resolve-String -Text $testItem.Configuration.Name) -cne $testItem.ADObject.Name) {
-							Rename-ADObject @parameters -Identity $testItem.ADObject.ObjectGUID -NewName (Resolve-String -Text $testItem.Configuration.Name) -ErrorAction Stop
+							Rename-ADObject @parameters -Identity $testItem.ADObject.ObjectGUID -NewName (Resolve-String -Text $testItem.Configuration.Name) -ErrorAction Stop -Confirm:$false
 						}
                     } -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
                 }
@@ -105,7 +105,7 @@
                         catch { Stop-PSFFunction -String 'Invoke-DMGroup.Group.Update.OUExistsNot' -StringValues $testItem.Identity, $targetOU -Target $testItem -EnableException $EnableException -Continue }
 
                         Invoke-PSFProtectedCommand -ActionString 'Invoke-DMGroup.Group.Move' -ActionStringValues $targetOU -Target $testItem -ScriptBlock {
-                            $null = Move-ADObject @parameters -Identity $testItem.ADObject.ObjectGUID -TargetPath $targetOU -ErrorAction Stop
+                            $null = Move-ADObject @parameters -Identity $testItem.ADObject.ObjectGUID -TargetPath $targetOU -ErrorAction Stop -Confirm:$false
                         } -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
                     }
                     $changes = @{ }
@@ -114,7 +114,7 @@
 					
                     if ($changes.Keys.Count -gt 0) {
                         Invoke-PSFProtectedCommand -ActionString 'Invoke-DMGroup.Group.Update' -ActionStringValues ($changes.Keys -join ", ") -Target $testItem -ScriptBlock {
-                            $null = Set-ADObject @parameters -Identity $testItem.ADObject.ObjectGUID -ErrorAction Stop -Replace $changes
+                            $null = Set-ADObject @parameters -Identity $testItem.ADObject.ObjectGUID -ErrorAction Stop -Replace $changes -Confirm:$false
                         } -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
                     }
                     if ($testItem.Changed -contains 'Scope') {
@@ -124,13 +124,13 @@
 						}
 
 						Invoke-PSFProtectedCommand -ActionString 'Invoke-DMGroup.Group.Update.Scope' -ActionStringValues $testItem, $testItem.ADObject.GroupScope, $targetScope -Target $testItem -ScriptBlock {
-							$null = Set-ADGroup @parameters -Identity $testItem.ADObject.ObjectGUID -GroupScope Universal -ErrorAction Stop
-							$null = Set-ADGroup @parameters -Identity $testItem.ADObject.ObjectGUID -GroupScope $targetScope -ErrorAction Stop
+							$null = Set-ADGroup @parameters -Identity $testItem.ADObject.ObjectGUID -GroupScope Universal -ErrorAction Stop -Confirm:$false
+							$null = Set-ADGroup @parameters -Identity $testItem.ADObject.ObjectGUID -GroupScope $targetScope -ErrorAction Stop -Confirm:$false
                         } -EnableException $EnableException.ToBool() -PSCmdlet $PSCmdlet -Continue
 					}
 					if ($testItem.Changed -contains 'Name') {
                         Invoke-PSFProtectedCommand -ActionString 'Invoke-DMGroup.Group.Update.Name' -ActionStringValues (Resolve-String -Text $testItem.Configuration.Name) -Target $testItem -ScriptBlock {
-                            $testItem.ADObject | Rename-ADObject @parameters -NewName (Resolve-String -Text $testItem.Configuration.Name) -ErrorAction Stop
+                            $testItem.ADObject | Rename-ADObject @parameters -NewName (Resolve-String -Text $testItem.Configuration.Name) -ErrorAction Stop -Confirm:$false
                         } -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
                     }
                 }

--- a/DomainManagement/functions/groups/Invoke-DMGroup.ps1
+++ b/DomainManagement/functions/groups/Invoke-DMGroup.ps1
@@ -70,7 +70,7 @@
                         Remove-ADGroup @parameters -Identity $testItem.ADObject.ObjectGUID -ErrorAction Stop -Confirm:$false
                     } -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
                 }
-                'ConfigurationOnly' {
+                'Create' {
                     $targetOU = Resolve-String -Text $testItem.Configuration.Path
                     try { $null = Get-ADObject @parameters -Identity $targetOU -ErrorAction Stop }
                     catch { Stop-PSFFunction -String 'Invoke-DMGroup.Group.Create.OUExistsNot' -StringValues $targetOU, $testItem.Identity -Target $testItem -EnableException $EnableException -Continue }

--- a/DomainManagement/functions/groups/Register-DMGroup.ps1
+++ b/DomainManagement/functions/groups/Register-DMGroup.ps1
@@ -1,5 +1,4 @@
-﻿function Register-DMGroup
-{
+﻿function Register-DMGroup {
 	<#
 	.SYNOPSIS
 		Registers an active directory group.
@@ -41,6 +40,9 @@
 		Whether the group should exist.
 		Defaults to $true
 		Set to $false for explicitly deleting groups, rather than creating them.
+
+	.PARAMETER Optional
+		Group is tolerated if it exists, but will not be created if not.
 
 	.PARAMETER ContextName
 		The name of the context defining the setting.
@@ -89,23 +91,26 @@
 		[bool]
 		$Present = $true,
 
+		[bool]
+		$Optional,
+
 		[string]
 		$ContextName = '<Undefined>'
 	)
 	
-	process
-	{
+	process {
 		$script:groups[$Name] = [PSCustomObject]@{
-			PSTypeName = 'DomainManagement.Group'
-			Name = $Name
+			PSTypeName     = 'DomainManagement.Group'
+			Name           = $Name
 			SamAccountName = $(if ($SamAccountName) { $SamAccountName } else { $Name })
-			Path = $Path
-			Description = $Description
-			Scope = $Scope
-			Category = $Category
-			OldNames = $OldNames
-			Present = $Present
-			ContextName = $ContextName
+			Path           = $Path
+			Description    = $Description
+			Scope          = $Scope
+			Category       = $Category
+			OldNames       = $OldNames
+			Present        = $Present
+			Optional       = $Optional
+			ContextName    = $ContextName
 		}
 	}
 }

--- a/DomainManagement/functions/groups/Test-DMGroup.ps1
+++ b/DomainManagement/functions/groups/Test-DMGroup.ps1
@@ -73,7 +73,9 @@
 					#region Case: No old version present
 					0
 					{
-						New-TestResult @resultDefaults -Type ConfigurationOnly
+						if (-not $groupDefinition.Optional) {
+							New-TestResult @resultDefaults -Type Create
+						}
 						continue main
 					}
 					#endregion Case: No old version present

--- a/DomainManagement/functions/object/Invoke-DMObject.ps1
+++ b/DomainManagement/functions/object/Invoke-DMObject.ps1
@@ -84,7 +84,7 @@
 						$createParam['OtherAttributes'] = $hash
 					}
 					Invoke-PSFProtectedCommand -ActionString 'Invoke-DMObject.Object.Create' -ActionStringValues $testItem.Configuration.ObjectClass, $testItem.Identity -Target $testItem -ScriptBlock {
-						New-ADObject @createParam -ErrorAction Stop
+						New-ADObject @createParam -ErrorAction Stop -Confirm:$false
 					} -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
 				}
 				'Changed' {
@@ -99,7 +99,7 @@
 					}
 					$setParam['Replace'] = $replaceHash
 					Invoke-PSFProtectedCommand -ActionString 'Invoke-DMObject.Object.Change' -ActionStringValues ($testItem.Changed -join ", ") -Target $testItem -ScriptBlock {
-						Set-ADObject @setParam -ErrorAction Stop
+						Set-ADObject @setParam -ErrorAction Stop -Confirm:$false
 					} -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
 				}
 			}

--- a/DomainManagement/functions/object/Register-DMObject.ps1
+++ b/DomainManagement/functions/object/Register-DMObject.ps1
@@ -38,7 +38,7 @@
 		[string]
 		$Path,
 
-		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
 		[string]
 		$Name,
 
@@ -56,9 +56,11 @@
 	
 	process
 	{
+		$identity = "CN=$Name,$Path"
+		if (-not $Name) { $identity = $Path }
 		$script:objects["CN=$Name,$Path"] = [PSCustomObject]@{
 			PSTypeName = 'DomainManagement.Object'
-			Identity = "CN=$Name,$Path"
+			Identity = $identity
 			Path = $Path
 			Name = $Name
 			ObjectClass = $ObjectClass

--- a/DomainManagement/functions/organizationalunits/Invoke-DMOrganizationalUnit.ps1
+++ b/DomainManagement/functions/organizationalunits/Invoke-DMOrganizationalUnit.ps1
@@ -103,7 +103,7 @@
 						if ($accidentProtectionRule = ($testItem.ADObject.nTSecurityDescriptor.Access | Where-Object { ($_.IdentityReference -eq $everyone) -and ($_.AccessControlType -eq 'Deny') }))
 						{
 							$null = $testItem.ADObject.nTSecurityDescriptor.RemoveAccessRule($accidentProtectionRule)
-							Set-ADObject @parameters -Identity $testItem.ADObject.DistinguishedName -Replace @{ nTSecurityDescriptor = $testItem.ADObject.nTSecurityDescriptor } -ErrorAction Stop
+							Set-ADObject @parameters -Identity $testItem.ADObject.DistinguishedName -Replace @{ nTSecurityDescriptor = $testItem.ADObject.nTSecurityDescriptor } -ErrorAction Stop -Confirm:$false
 						}
 						Remove-ADOrganizationalUnit @parameters -Identity $testItem.ADObject.ObjectGUID -ErrorAction Stop -Confirm:$false
 					} -EnableException $EnableException.ToBool() -PSCmdlet $PSCmdlet -Continue
@@ -128,7 +128,7 @@
 				}
 				'Rename' {
 					Invoke-PSFProtectedCommand -ActionString 'Invoke-DMOrganizationalUnit.OU.Rename' -ActionStringValues (Resolve-String -Text $testItem.Configuration.Name) -Target $testItem -ScriptBlock {
-						Rename-ADObject @parameters -Identity $testItem.ADObject.ObjectGUID -NewName (Resolve-String -Text $testItem.Configuration.Name) -ErrorAction Stop
+						Rename-ADObject @parameters -Identity $testItem.ADObject.ObjectGUID -NewName (Resolve-String -Text $testItem.Configuration.Name) -ErrorAction Stop -Confirm:$false
 					} -EnableException $EnableException.ToBool() -PSCmdlet $PSCmdlet -Continue
 				}
 				'Changed' {
@@ -138,7 +138,7 @@
 					if ($changes.Keys.Count -gt 0)
 					{
 						Invoke-PSFProtectedCommand -ActionString 'Invoke-DMOrganizationalUnit.OU.Update' -ActionStringValues ($changes.Keys -join ", ") -Target $testItem -ScriptBlock {
-							$null = Set-ADObject @parameters -Identity $testItem.ADObject.ObjectGUID -ErrorAction Stop -Replace $changes
+							$null = Set-ADObject @parameters -Identity $testItem.ADObject.ObjectGUID -ErrorAction Stop -Replace $changes -Confirm:$false
 						} -EnableException $EnableException.ToBool() -PSCmdlet $PSCmdlet -Continue
 					}
 				}

--- a/DomainManagement/functions/users/Invoke-DMUser.ps1
+++ b/DomainManagement/functions/users/Invoke-DMUser.ps1
@@ -111,7 +111,7 @@
 						catch { Stop-PSFFunction -String 'Invoke-DMUser.User.Update.OUExistsNot' -StringValues $testItem.Identity, $targetOU -Target $testItem -EnableException $EnableException -Continue -ContinueLabel main }
 						
 						Invoke-PSFProtectedCommand -ActionString 'Invoke-DMUser.User.Move' -ActionStringValues $targetOU -Target $testItem -ScriptBlock {
-							$null = Move-ADObject @parameters -Identity $testItem.ADObject.ObjectGUID -TargetPath $targetOU -ErrorAction Stop
+							$null = Move-ADObject @parameters -Identity $testItem.ADObject.ObjectGUID -TargetPath $targetOU -ErrorAction Stop -Confirm:$false
 						} -EnableException $EnableException.ToBool() -PSCmdlet $PSCmdlet -Continue
 					}
 					$changes = @{ }
@@ -122,23 +122,23 @@
 					
 					if ($changes.Keys.Count -gt 0) {
 						Invoke-PSFProtectedCommand -ActionString 'Invoke-DMUser.User.Update' -ActionStringValues ($changes.Keys -join ", ") -Target $testItem -ScriptBlock {
-							$null = Set-ADObject @parameters -Identity $testItem.ADObject.ObjectGUID -ErrorAction Stop -Replace $changes
+							$null = Set-ADObject @parameters -Identity $testItem.ADObject.ObjectGUID -ErrorAction Stop -Replace $changes -Confirm:$false
 						} -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
 					}
 					
 					if ($testItem.Changed -contains 'Enabled') {
 						Invoke-PSFProtectedCommand -ActionString 'Invoke-DMUser.User.Update.EnableDisable' -ActionStringValues $testItem.Configuration.Enabled -Target $testItem -ScriptBlock {
-							$null = Set-ADUser @parameters -Identity $testItem.ADObject.ObjectGUID -ErrorAction Stop -Enabled $testItem.Configuration.Enabled
+							$null = Set-ADUser @parameters -Identity $testItem.ADObject.ObjectGUID -ErrorAction Stop -Enabled $testItem.Configuration.Enabled -Confirm:$false
 						} -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
 					}
 					if ($testItem.Changed -contains 'Name') {
 						Invoke-PSFProtectedCommand -ActionString 'Invoke-DMUser.User.Update.Name' -ActionStringValues (Resolve-String -Text $testItem.Configuration.Name) -Target $testItem -ScriptBlock {
-							Rename-ADObject @parameters -Identity $testItem.ADObject.ObjectGUID -NewName (Resolve-String -Text $testItem.Configuration.Name) -ErrorAction Stop
+							Rename-ADObject @parameters -Identity $testItem.ADObject.ObjectGUID -NewName (Resolve-String -Text $testItem.Configuration.Name) -ErrorAction Stop -Confirm:$false
 						} -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
 					}
 					if ($testItem.Changed -contains 'PasswordNeverExpires') {
 						Invoke-PSFProtectedCommand -ActionString 'Invoke-DMUser.User.Update.PasswordNeverExpires' -ActionStringValues $testItem.Configuration.PasswordNeverExpires -Target $testItem -ScriptBlock {
-							$null = Set-ADUser @parameters -Identity $testItem.ADObject.ObjectGUID -ErrorAction Stop -PasswordNeverExpires $testItem.Configuration.PasswordNeverExpires
+							$null = Set-ADUser @parameters -Identity $testItem.ADObject.ObjectGUID -ErrorAction Stop -PasswordNeverExpires $testItem.Configuration.PasswordNeverExpires -Confirm:$false
 						} -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
 					}
 				}

--- a/DomainManagement/internal/functions/Assert-Configuration.ps1
+++ b/DomainManagement/internal/functions/Assert-Configuration.ps1
@@ -24,7 +24,7 @@
 	[CmdletBinding()]
 	Param (
 		[Parameter(Mandatory = $true)]
-		[string]
+		[string[]]
 		$Type,
 
 		[Parameter(Mandatory = $true)]
@@ -34,14 +34,16 @@
 	
 	process
 	{
-		if ((Get-Variable -Name $Type -Scope Script -ValueOnly).Count -gt 0) { return }
+		foreach ($typeName in $type) {
+			if ((Get-Variable -Name $typeName -Scope Script -ValueOnly).Count -gt 0) { return }
+		}
 		
-		Write-PSFMessage -Level Warning -String 'Assert-Configuration.NotConfigured' -StringValues $Type -FunctionName $Cmdlet.CommandRuntime
+		Write-PSFMessage -Level Warning -String 'Assert-Configuration.NotConfigured' -StringValues ($Type -join ", ") -FunctionName $Cmdlet.CommandRuntime
 
-		$exception = New-Object System.Data.DataException("No configuration data provided for: $Type")
+		$exception = New-Object System.Data.DataException("No configuration data provided for: $($Type -join ", ")")
 		$errorID = 'NotConfigured'
 		$category = [System.Management.Automation.ErrorCategory]::NotSpecified
-		$recordObject = New-Object System.Management.Automation.ErrorRecord($exception, $errorID, $category, $Type)
+		$recordObject = New-Object System.Management.Automation.ErrorRecord($exception, $errorID, $category, ($Type -join ", "))
 		$cmdlet.ThrowTerminatingError($recordObject)
 	}
 }

--- a/DomainManagement/internal/functions/Resolve-ADObject.ps1
+++ b/DomainManagement/internal/functions/Resolve-ADObject.ps1
@@ -6,7 +6,7 @@
 	.DESCRIPTION
 		Resolves AD Objects from wildcard-patterned Distinguished Names.
 	
-	.PARAMETER OUFilter
+	.PARAMETER Filter
 		The wildcard-patterned DN
 	
 	.PARAMETER Server

--- a/DomainManagement/internal/functions/Resolve-ADObject.ps1
+++ b/DomainManagement/internal/functions/Resolve-ADObject.ps1
@@ -1,0 +1,74 @@
+﻿function Resolve-ADObject {
+	<#
+	.SYNOPSIS
+		Resolves AD Objects from wildcard-patterned DNs.
+	
+	.DESCRIPTION
+		Resolves AD Objects from wildcard-patterned Distinguished Names.
+	
+	.PARAMETER OUFilter
+		The wildcard-patterned DN
+	
+	.PARAMETER Server
+		The server / domain to work with.
+	
+	.PARAMETER Credential
+		The credentials to use for this operation.
+	
+	.PARAMETER ObjectClass
+		Only return objects of the specified object class.
+		Default: *
+	
+	.EXAMPLE
+		PS C:\> Resolve-ADObject -OUFilter '*,*,OU=Contoso,DC=contoso,DC=com' -ObjectClass user
+
+		Resolves all user objects two steps under the Contoso OU.
+	#>
+	[CmdletBinding()]
+	param (
+		[Parameter(ValueFromPipeline = $true, Mandatory = $true)]
+		[string]
+		$Filter,
+
+		[PSFComputer]
+		$Server,
+
+		[PSCredential]
+		$Credential,
+
+		[string]
+		$ObjectClass = '*'
+	)
+
+	begin {
+		function Get-AdNextStep {
+			[CmdletBinding()]
+			param (
+				$Parameters,
+	
+				$Fragments,
+	
+				$BasePath
+			)
+	
+			$nameFilter = (@($Fragments)[0] -split "=",2)[-1]
+			$adObjects = Get-ADObject @Parameters -SearchBase $BasePath -SearchScope OneLevel -LDAPFilter "(name=$nameFilter)"
+			if (@($Fragments).Count -eq 1) {
+				return $adObjects
+			}
+	
+			foreach ($adObject in $adObjects) {
+				Get-AdNextStep -Parameters $Parameters -BasePath $adObject.DistinguishedName -Fragments $Fragments[1..$Fragments.Length]
+			}
+		}
+		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
+	}
+	
+	process {
+		$filterSegments = ($Filter -replace ",DC=.+$" -split "(?<=[^\\],)").TrimEnd(",")
+		$basePath = $Filter -replace '^.+?,DC=','DC='
+		[array]::Reverse($filterSegments)
+	
+		Get-AdNextStep -Parameters $parameters -Fragments $filterSegments -BasePath $basePath | Where-Object ObjectClass -Like $ObjectClass
+	}
+}

--- a/DomainManagement/internal/functions/groupPolicy/ConvertTo-GPLink.ps1
+++ b/DomainManagement/internal/functions/groupPolicy/ConvertTo-GPLink.ps1
@@ -32,7 +32,7 @@
             "0" = 'Enabled'
             "1" = 'Disabled'
             "2" = 'Enforced'
-        }
+		}
     }
     process {
         foreach ($adItem in $ADObject) {
@@ -56,7 +56,14 @@
                         'Disabled' { '~|{0}' -f $this.DisplayName }
                         'Enforced' { '*|{0}' -f $this.DisplayName }
                     }
-                } -Force
+				} -Force
+				Add-Member -InputObject $linkObject -MemberType ScriptMethod -Name ToLink -Value {
+					# [LDAP://cn={F4A6ADB1-BEDE-497D-901F-F24B19394951},cn=policies,cn=system,DC=contoso,DC=com;0][LDAP://cn={2036B9B6-D5C1-4756-B7AB-8291A9B26521},cn=policies,cn=system,DC=contoso,DC=com;0]
+					$status = '0'
+					if ($this.Status -eq 'Disabled') { $status = '1' }
+					if ($this.Status -eq 'Enforced') { $status = '2' }
+					'[LDAP://{0};{1}]' -f $this.DistinguishedName, $status
+				}
                 $linkObject
                 $index--
             }

--- a/DomainManagement/internal/functions/groupPolicy/Install-GroupPolicy.ps1
+++ b/DomainManagement/internal/functions/groupPolicy/Install-GroupPolicy.ps1
@@ -49,7 +49,7 @@
 	}
 	process {
 		Write-PSFMessage -Level Debug -String 'Install-GroupPolicy.CopyingFiles' -StringValues $Configuration.DisplayName -Target $Configuration
-		try { Copy-Item -Path $Configuration.Path -Destination $WorkingDirectory -Recurse -ToSession $Session -ErrorAction Stop -Force }
+		try { Copy-Item -Path $Configuration.Path -Destination $WorkingDirectory -Recurse -ToSession $Session -ErrorAction Stop -Force -Confirm:$false }
 		catch { Stop-PSFFunction @stopDefault -String 'Install-GroupPolicy.CopyingFiles.Failed' -StringValues $Configuration.DisplayName -ErrorRecord $_ }
 		
 		#region Installing Group Policy Object

--- a/DomainManagement/internal/scripts/variables.ps1
+++ b/DomainManagement/internal/scripts/variables.ps1
@@ -31,6 +31,7 @@ $script:groupPolicyRegistrySettings = @{ }
 
 # Configured group policy links
 $script:groupPolicyLinks = @{ }
+$script:groupPolicyLinksDynamic = @{ }
 
 # Configured group policy permission filters
 $script:groupPolicyPermissionFilters = @{ }
@@ -40,6 +41,8 @@ $script:groupPolicyPermissions = @{ }
 
 # Configured ACLs
 $script:acls = @{ }
+$script:aclByCategory = @{ }
+$script:aclDefaultOwner = $null
 
 # Configured Access Rules - Based on OU / Path
 $script:accessRules = @{ }

--- a/DomainManagement/tests/general/FileIntegrity.Exceptions.ps1
+++ b/DomainManagement/tests/general/FileIntegrity.Exceptions.ps1
@@ -31,7 +31,7 @@ $global:MayContainCommand = @{
 	"Write-Verbose" = @()
 	"Write-Warning" = @()
 	"Write-Error"  = @()
-	"Write-Output" = @('Get-DMAccessRule.ps1', 'Test-DMGPPermission.ps1', 'Test-DMGPRegistrySetting.ps1', 'Install-GroupPolicy.ps1', 'Test-DMObject.ps1')
+	"Write-Output" = @('Get-DMAccessRule.ps1', 'Test-DMGPPermission.ps1', 'Test-DMGPRegistrySetting.ps1', 'Install-GroupPolicy.ps1', 'Test-DMObject.ps1', 'Test-DMGPLink.ps1')
 	"Write-Information" = @()
 	"Write-Debug" = @()
 }

--- a/DomainManagement/tests/general/PSScriptAnalyzer.Tests.ps1
+++ b/DomainManagement/tests/general/PSScriptAnalyzer.Tests.ps1
@@ -12,7 +12,10 @@ if ($SkipTest) { return }
 $global:__pester_data.ScriptAnalyzer = New-Object System.Collections.ArrayList
 
 Describe 'Invoking PSScriptAnalyzer against commandbase' {
-	$commandFiles = Get-ChildItem -Path $CommandPath -Recurse | Where-Object Name -like "*.ps1"
+	
+	$commandFiles = foreach ($pathItem in $CommandPath) {
+		Get-ChildItem -Path $pathItem -Recurse | Where-Object Name -like "*.ps1"
+	}
 	$scriptAnalyzerRules = Get-ScriptAnalyzerRule
 	
 	foreach ($file in $commandFiles)

--- a/DomainManagement/xml/DomainManagement.Format.ps1xml
+++ b/DomainManagement/xml/DomainManagement.Format.ps1xml
@@ -102,6 +102,46 @@ else { $_.ObjectCategory }
             </TableControl>
         </View>
 
+        <!-- DomainManagement.Acl -->
+        <View>
+            <Name>DomainManagement.Acl</Name>
+            <ViewSelectedBy>
+                <TypeName>DomainManagement.Acl</TypeName>
+            </ViewSelectedBy>
+            <TableControl>
+                <AutoSize/>
+                <TableHeaders>
+                    <TableColumnHeader>
+                        <Label>Path/Category</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader/>
+                    <TableColumnHeader/>
+                    <TableColumnHeader/>
+                </TableHeaders>
+                <TableRowEntries>
+                    <TableRowEntry>
+                        <TableColumnItems>
+                            <TableColumnItem>
+                                <ScriptBlock>
+if ($_.Path) { $_.Path }
+else { $_.Category }
+                                </ScriptBlock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Owner</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>NoInheritance</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Optional</PropertyName>
+                            </TableColumnItem>
+                        </TableColumnItems>
+                    </TableRowEntry>
+                </TableRowEntries>
+            </TableControl>
+        </View>
+
         <!-- DomainManagement.GPLink.Update -->
         <View>
             <Name>DomainManagement.GPLink.Update</Name>

--- a/DomainManagement/xml/DomainManagement.Format.ps1xml
+++ b/DomainManagement/xml/DomainManagement.Format.ps1xml
@@ -102,6 +102,37 @@ else { $_.ObjectCategory }
             </TableControl>
         </View>
 
+        <!-- DomainManagement.GPLink.Update -->
+        <View>
+            <Name>DomainManagement.GPLink.Update</Name>
+            <ViewSelectedBy>
+                <TypeName>DomainManagement.GPLink.Update</TypeName>
+            </ViewSelectedBy>
+            <TableControl>
+                <AutoSize/>
+                <TableHeaders>
+                    <TableColumnHeader/>
+                    <TableColumnHeader/>
+                    <TableColumnHeader/>
+                </TableHeaders>
+                <TableRowEntries>
+                    <TableRowEntry>
+                        <TableColumnItems>
+                            <TableColumnItem>
+                                <PropertyName>Action</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Policy</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Status</PropertyName>
+                            </TableColumnItem>
+                        </TableColumnItems>
+                    </TableRowEntry>
+                </TableRowEntries>
+            </TableControl>
+        </View>
+
         <!-- DomainManagement.Configuration.GPPermissionFilter -->
         <View>
             <Name>DomainManagement.Configuration.GPPermissionFilter</Name>


### PR DESCRIPTION
- Upd: Register-DMGroup - added parameter `-Optional` to make a group optional
- Upd: Renamed test result type `ConfigurationOnly` to `Create`
- Upd: Test-DMGroup - don't create Create actions for groups that are optional
- Upd: GPLink - added capability for dynamic path assignments
- Upd: GPLink - added processing modes to enable adding without removing unknown, as well as explicit delete orders
- Upd: GPLink - new priority system called tier. This enables grouping GPOs by category in separate priority sets
- Upd: ACL - added capability to define default ownership of objects under management
- Upd: ACL - added capability to define ownership and inheritance by object category for objects under management
- Fix: Test-GPPermission - path-based filters would not correctly map permissions
- Fix: Component Object - Does not allow modifying properties on the domain object itself
- Fix: Various - Removed duplicate confirm prompts from several invoke commands
- Fix: Invoke-DMGPPermission - handled error when identity could not be resolved (e.g. when a group does not exist but has assigned permissions)