### PR TITLE
1.5.111

### DIFF
--- a/DomainManagement/DomainManagement.psd1
+++ b/DomainManagement/DomainManagement.psd1
@@ -3,7 +3,7 @@
 	RootModule         = 'DomainManagement.psm1'
 	
 	# Version number of this module.
-	ModuleVersion      = '1.4.99'
+	ModuleVersion      = '1.5.101'
 	
 	# ID used to uniquely identify this module
 	GUID               = '0a405382-ebc2-445b-8325-541535810193'
@@ -47,6 +47,7 @@
 	FunctionsToExport  = @(
 		'Clear-DMConfiguration'
 		'Convert-DMSchemaGuid'
+		'Find-DMObjectCategoryItem'
 		'Get-DMAccessRule'
 		'Get-DMAccessRuleMode'
 		'Get-DMAcl'
@@ -68,6 +69,7 @@
 		'Get-DMObjectDefaultPermission'
 		'Get-DMOrganizationalUnit'
 		'Get-DMPasswordPolicy'
+		'Get-DMServiceAccount'
 		'Get-DMUser'
 		'Invoke-DMAccessRule'
 		'Invoke-DMAcl'
@@ -81,6 +83,7 @@
 		'Invoke-DMObject'
 		'Invoke-DMOrganizationalUnit'
 		'Invoke-DMPasswordPolicy'
+		'Invoke-DMServiceAccount'
 		'Invoke-DMUser'
 		'Register-DMAccessRule'
 		'Register-DMAccessRuleMode'
@@ -101,6 +104,7 @@
 		'Register-DMObjectCategory'
 		'Register-DMOrganizationalUnit'
 		'Register-DMPasswordPolicy'
+		'Register-DMServiceAccount'
 		'Register-DMUser'
 		'Reset-DMDomainCredential'
 		'Resolve-DMAccessRuleMode'
@@ -121,6 +125,7 @@
 		'Test-DMObject'
 		'Test-DMOrganizationalUnit'
 		'Test-DMPasswordPolicy'
+		'Test-DMServiceAccount'
 		'Test-DMUser'
 		'Unregister-DMAccessRule'
 		'Unregister-DMAccessRuleMode'
@@ -140,6 +145,7 @@
 		'Unregister-DMObjectCategory'
 		'Unregister-DMOrganizationalUnit'
 		'Unregister-DMPasswordPolicy'
+		'Unregister-DMServiceAccount'
 		'Unregister-DMUser'
 	)
 	

--- a/DomainManagement/DomainManagement.psd1
+++ b/DomainManagement/DomainManagement.psd1
@@ -3,7 +3,7 @@
 	RootModule         = 'DomainManagement.psm1'
 	
 	# Version number of this module.
-	ModuleVersion      = '1.5.101'
+	ModuleVersion      = '1.5.111'
 	
 	# ID used to uniquely identify this module
 	GUID               = '0a405382-ebc2-445b-8325-541535810193'

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -1,6 +1,6 @@
 ﻿# Changelog
 
-## 1.5.101 (2021-01-15)
+## 1.5.111 (2021-01-15)
 
 - New: Component: Service Accounts - manage Group Managed Service Accounts
 - New: Command Find-DMObjectCategoryItem - Searches objects that are part of a specified object category.

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -1,5 +1,16 @@
 ﻿# Changelog
 
+## ???
+
+- Upd: GroupMembership - allowed computer objects
+- Upd: Organizational Units - added option for "optional", tolerating an existing OU but not creating it
+- Upd: Organizational Units - renamed change type "ConfigurationOnly" to "Create"
+- Upd: Organizational Units - renamed change type "ShouldDelete" to "Delete"
+- Upd: Users - added option for "optional", tolerating an existing OU but not creating it
+- Upd: Users - renamed change type "ConfigurationOnly" to "Create"
+- Upd: Users - renamed change type "ShouldDelete" to "Delete"
+- Fix: Test-DMGroupMembership - incorrectly reports foreign security principals that were resolved as "unidentified" if another fsp was incorrectly a group member.
+
 ## 1.4.99 (2020-12-11)
 
 - Fix: Get-DMGPLink - returns null objects as part of return

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -1,7 +1,11 @@
 ﻿# Changelog
 
-## ???
+## 1.5.101 (2021-01-15)
 
+- New: Component: Service Accounts - manage Group Managed Service Accounts
+- New: Command Find-DMObjectCategoryItem - Searches objects that are part of a specified object category.
+- Upd: Register-DMObjectCategory - Added SearchBase and SearchScope parameters.
+- Upd: Resolve-DMObjectCategory - Added support for Searchbase and Searchscope of object categories.
 - Upd: GroupMembership - allowed computer objects
 - Upd: Organizational Units - added option for "optional", tolerating an existing OU but not creating it
 - Upd: Organizational Units - renamed change type "ConfigurationOnly" to "Create"

--- a/DomainManagement/en-us/strings.psd1
+++ b/DomainManagement/en-us/strings.psd1
@@ -1,199 +1,215 @@
 ﻿# This is where the strings go, that are written by
 # Write-PSFMessage, Stop-PSFFunction or the PSFramework validation scriptblocks
 @{
-	'Assert-ADConnection.Failed'                                    = 'Failed to connect to {0}' # $Server
+	'Assert-ADConnection.Failed'								    = 'Failed to connect to {0}' # $Server
 	
-	'Assert-Configuration.NotConfigured'                            = 'No configuration data provided for: {0}' # $Type
+	'Assert-Configuration.NotConfigured'						    = 'No configuration data provided for: {0}' # ($Type -join ", ")
 	
-	'Convert-AccessRule.Identity.ResolutionError'                   = 'Failed to convert identity. This generally means a configuration error, especially when referencing the parent as identity.' # 
+	'Convert-AccessRule.Identity.ResolutionError'				    = 'Failed to convert identity. This generally means a configuration error, especially when referencing the parent as identity.' # 
 	
-	'Convert-Principal.Processing'                                  = 'Converting principal: {0}' # $Name
-	'Convert-Principal.Processing.InputNT'                          = 'Input detected as NT: {0}' # $Name
-	'Convert-Principal.Processing.InputSID'                         = 'Input detected as SID: {0}' # $Name
-	'Convert-Principal.Processing.NT.LdapFilter'                    = 'Resolving NT identity via AD using the following filter: {0}' # "(samAccountName=$namePart)"
-	'Convert-Principal.Processing.NTDetails'                        = 'Resolved NT identity: Domain = {0} | Name = {1}' # $domainPart, $namePart
+	'Convert-Principal.Processing'								    = 'Converting principal: {0}' # $Name
+	'Convert-Principal.Processing.InputNT'						    = 'Input detected as NT: {0}' # $Name
+	'Convert-Principal.Processing.InputSID'						    = 'Input detected as SID: {0}' # $Name
+	'Convert-Principal.Processing.NT.LdapFilter'				    = 'Resolving NT identity via AD using the following filter: {0}' # "(samAccountName=$namePart)"
+	'Convert-Principal.Processing.NTDetails'					    = 'Resolved NT identity: Domain = {0} | Name = {1}' # $domainPart, $namePart
 	
-	'General.Invalid.Input'                                         = 'Invalid input: {1}! This command only accepts output objects from {0}' # 'Test-DMAccessRule', $testItem
+	'Find-DMObjectCategoryItem.ADError'							    = 'Error retrieving AD Objects for object category {0}' # $Name
+	'Find-DMObjectCategoryItem.Category.NotFound'				    = 'No such object category defined: {0}' # $Name
 	
-	'Get-PermissionGuidMapping.Processing'                          = 'Processing Permission Guids for domain: {0} (This may take a while)' # $identity
+	'General.Invalid.Input'										    = 'Invalid input: {1}! This command only accepts output objects from {0}' # 'Test-DMAccessRule', $testItem
 	
-	'Get-Principal.Resolution.Failed'                               = 'Failed to resolve principal: SID {0} | Name {1} | ObjectClass {2} | Domain {3}' # $Sid, $Name, $ObjectClass, $Domain
+	'Get-PermissionGuidMapping.Processing'						    = 'Processing Permission Guids for domain: {0} (This may take a while)' # $identity
 	
-	'Get-SchemaGuidMapping.Processing'                              = 'Processing Schema Guids for domain: {0} (This may take a while)' # $identity
+	'Get-Principal.Resolution.Failed'							    = 'Failed to resolve principal: SID {0} | Name {1} | ObjectClass {2} | Domain {3}' # $Sid, $Name, $ObjectClass, $Domain
 	
-	'Install-GroupPolicy.CopyingFiles'                              = 'Copying GPO files for "{0}"' # $Configuration.DisplayName
-	'Install-GroupPolicy.CopyingFiles.Failed'                       = 'Failed to copy the GPO files for "{0}"' # $Configuration.DisplayName
-	'Install-GroupPolicy.DeletingImportFiles'                       = 'Deleting the GPO files for "{0}"' # $Configuration.DisplayName
-	'Install-GroupPolicy.Importing.RegistryValues'                  = 'Applying registry settings to GPO "{0}"' # $Configuration.DisplayName
-	'Install-GroupPolicy.Importing.RegistryValues.Failed'           = 'Failed to apply registry settings to GPO "{0}": {1} --> {2}' # $Configuration.DisplayName, $registryDatum.Key, $registryDatum.ValueName
-	'Install-GroupPolicy.ImportingConfiguration'                    = 'Importing the GPO "{0}" from the defined source files' # $Configuration.DisplayName
-	'Install-GroupPolicy.ImportingConfiguration.Failed'             = 'Failed to impoter the GPO "{0}"' # $Configuration.DisplayName
-	'Install-GroupPolicy.ReadingADObject'                           = 'Reading the AD object of the imported GPO: "{0}"' # $Configuration.DisplayName
-	'Install-GroupPolicy.ReadingADObject.Failed.Error'              = 'Failed to access the GPO AD object of "{0}", could not validate creation!' # $Configuration.DisplayName
-	'Install-GroupPolicy.ReadingADObject.Failed.NoObject'           = 'The AD object for GPO "{0}" cannot be found! Please manually verify succcess and troubleshoot the creation process/environment.' # $Configuration.DisplayName
-	'Install-GroupPolicy.ReadingADObject.Failed.Timestamp'          = 'Failed to vallidate import of the GPO "{0}". Its last modified timestamp ({1}) is older than the time the import started ({2}). This would usually be the case when the GPO already existed before the process and the import failed for some reason. Please troubleshoot the GPO creation process and the target environment.' # $Configuration.DisplayName, $policyObject.Modified, $timestamp
-	'Install-GroupPolicy.UpdatingConfigurationFile'                 = 'Updating the configuration metadata file for "{0}" on the target domain.' # $Configuration.DisplayName
-	'Install-GroupPolicy.UpdatingConfigurationFile.Failed'          = 'Failed to update the configuration metadata file for "{0}" on the target domain. This will cause the GPO to not register as managed and will be flagged as to update on the next test. Please validate filesystem write access to the targeted GPO.' # $Configuration.DisplayName
+	'Get-SchemaGuidMapping.Processing'							    = 'Processing Schema Guids for domain: {0} (This may take a while)' # $identity
 	
-	'Invoke-Callback.Invoking'                                      = 'Executing callback: {0}' # $callback.Name
-	'Invoke-Callback.Invoking.Failed'                               = 'Error executing callback: {0}' # $callback.Name
-	'Invoke-Callback.Invoking.Success'                              = 'Successfully executed callback: {0}' # $callback.Name
+	'Install-GroupPolicy.CopyingFiles'							    = 'Copying GPO files for "{0}"' # $Configuration.DisplayName
+	'Install-GroupPolicy.CopyingFiles.Failed'					    = 'Failed to copy the GPO files for "{0}"' # $Configuration.DisplayName
+	'Install-GroupPolicy.DeletingImportFiles'					    = 'Deleting the GPO files for "{0}"' # $Configuration.DisplayName
+	'Install-GroupPolicy.Importing.RegistryValues'				    = 'Applying registry settings to GPO "{0}"' # $Configuration.DisplayName
+	'Install-GroupPolicy.Importing.RegistryValues.Failed'		    = 'Failed to apply registry settings to GPO "{0}": {1} --> {2}' # $Configuration.DisplayName, $registryDatum.Key, $registryDatum.ValueName
+	'Install-GroupPolicy.ImportingConfiguration'				    = 'Importing the GPO "{0}" from the defined source files' # $Configuration.DisplayName
+	'Install-GroupPolicy.ImportingConfiguration.Failed'			    = 'Failed to impoter the GPO "{0}"' # $Configuration.DisplayName
+	'Install-GroupPolicy.ReadingADObject'						    = 'Reading the AD object of the imported GPO: "{0}"' # $Configuration.DisplayName
+	'Install-GroupPolicy.ReadingADObject.Failed.Error'			    = 'Failed to access the GPO AD object of "{0}", could not validate creation!' # $Configuration.DisplayName
+	'Install-GroupPolicy.ReadingADObject.Failed.NoObject'		    = 'The AD object for GPO "{0}" cannot be found! Please manually verify succcess and troubleshoot the creation process/environment.' # $Configuration.DisplayName
+	'Install-GroupPolicy.ReadingADObject.Failed.Timestamp'		    = 'Failed to vallidate import of the GPO "{0}". Its last modified timestamp ({1}) is older than the time the import started ({2}). This would usually be the case when the GPO already existed before the process and the import failed for some reason. Please troubleshoot the GPO creation process and the target environment.' # $Configuration.DisplayName, $policyObject.Modified, $timestamp
+	'Install-GroupPolicy.UpdatingConfigurationFile'				    = 'Updating the configuration metadata file for "{0}" on the target domain.' # $Configuration.DisplayName
+	'Install-GroupPolicy.UpdatingConfigurationFile.Failed'		    = 'Failed to update the configuration metadata file for "{0}" on the target domain. This will cause the GPO to not register as managed and will be flagged as to update on the next test. Please validate filesystem write access to the targeted GPO.' # $Configuration.DisplayName
 	
-	'Invoke-DMAccessRule.Access.Failed'                             = 'Failed to access ACL on {0}' # $testItem.Identity
-	'Invoke-DMAccessRule.AccessRule.Create'                         = 'Adding access rule for {0}, granting {1} ({2})' # $changeEntry.Configuration.IdentityReference, $changeEntry.Configuration.ActiveDirectoryRights, $changeEntry.Configuration.AccessControlType
-	'Invoke-DMAccessRule.AccessRule.Creation.Failed'                = 'Failed to create accessrule at {0} for {1}' # $testItem.Identity, $changeEntry.Configuration.IdentityReference
-	'Invoke-DMAccessRule.AccessRule.Remove'                         = 'Removing access rule for {0}, granting {1} ({2})' # $changeEntry.ADObject.IdentityReference, $changeEntry.ADObject.ActiveDirectoryRights, $changeEntry.ADObject.AccessControlType
-	'Invoke-DMAccessRule.AccessRule.Remove.Failed'                  = 'Failed to removing access rule for {0}, granting {1} ({2}) for unknown reasons (sorry)' # $changeEntry.ADObject.IdentityReference, $changeEntry.ADObject.ActiveDirectoryRights, $changeEntry.ADObject.AccessControlType
-	'Invoke-DMAccessRule.ADObject.Missing'                          = 'Cannot process access rules, due to missing AD object: {0}. Please ensure the domain object is created before trying to apply rules to it!' # $testItem.Identity
-	'Invoke-DMAccessRule.Processing.Execute'                        = 'Applying {0} out of {1} intended access rule changes' # ($testItem.Changed.Count - $failedCount), $testItem.Changed.Count
-	'Invoke-DMAccessRule.Processing.Rules'                          = 'Processing {1} access rule changes on {0}' # $testItem.Identity, $testItem.Changed.Count
+	'Invoke-Callback.Invoking'									    = 'Executing callback: {0}' # $callback.Name
+	'Invoke-Callback.Invoking.Failed'							    = 'Error executing callback: {0}' # $callback.Name
+	'Invoke-Callback.Invoking.Success'							    = 'Successfully executed callback: {0}' # $callback.Name
 	
-	'Invoke-DMAcl.MissingADObject'                                  = 'The target object could not be found: {0}' # $testItem.Identity
-	'Invoke-DMAcl.NoAccess'                                         = 'Failed to access Acl on {0}' # $testItem.Identity
-	'Invoke-DMAcl.OwnerNotResolved'                                 = 'Was unable to resolve the current owner ({1}) of {0}' # $testItem.Identity, $testItem.ADObject.GetOwner([System.Security.Principal.SecurityIdentifier])
-	'Invoke-DMAcl.ShouldManage'                                     = 'The ADObject {0} has no defined ACL state and should either be configured or removed' # $testItem.Identity
-	'Invoke-DMAcl.UpdatingInheritance'                              = 'Updating inheritance - Inheritance Disabled: {0}' # $testItem.Configuration.NoInheritance
-	'Invoke-DMAcl.UpdatingOwner'                                    = 'Granting ownership to {0}' # ($testItem.Configuration.Owner | Resolve-String)
+	'Invoke-DMAccessRule.Access.Failed'							    = 'Failed to access ACL on {0}' # $testItem.Identity
+	'Invoke-DMAccessRule.AccessRule.Create'						    = 'Adding access rule for {0}, granting {1} ({2})' # $changeEntry.Configuration.IdentityReference, $changeEntry.Configuration.ActiveDirectoryRights, $changeEntry.Configuration.AccessControlType
+	'Invoke-DMAccessRule.AccessRule.Creation.Failed'			    = 'Failed to create accessrule at {0} for {1}' # $testItem.Identity, $changeEntry.Configuration.IdentityReference
+	'Invoke-DMAccessRule.AccessRule.Remove'						    = 'Removing access rule for {0}, granting {1} ({2})' # $changeEntry.ADObject.IdentityReference, $changeEntry.ADObject.ActiveDirectoryRights, $changeEntry.ADObject.AccessControlType
+	'Invoke-DMAccessRule.AccessRule.Remove.Failed'				    = 'Failed to removing access rule for {0}, granting {1} ({2}) for unknown reasons (sorry)' # $changeEntry.ADObject.IdentityReference, $changeEntry.ADObject.ActiveDirectoryRights, $changeEntry.ADObject.AccessControlType
+	'Invoke-DMAccessRule.ADObject.Missing'						    = 'Cannot process access rules, due to missing AD object: {0}. Please ensure the domain object is created before trying to apply rules to it!' # $testItem.Identity
+	'Invoke-DMAccessRule.Processing.Execute'					    = 'Applying {0} out of {1} intended access rule changes' # ($testItem.Changed.Count - $failedCount), $testItem.Changed.Count
+	'Invoke-DMAccessRule.Processing.Rules'						    = 'Processing {1} access rule changes on {0}' # $testItem.Identity, $testItem.Changed.Count
 	
-	'Invoke-DMDomainData.Invocation.Error'                          = 'An exception was thrown while executing the domain data script "{0}".' # $Name
-	'Invoke-DMDomainData.Invocation.Error.Terminate'                = 'Critical Error: An exception was thrown while executing the domain data script "{0}".' # $Name
-	'Invoke-DMDomainData.Script.NotFound'                           = 'Could not find a registered DomainData set with the name "{0}". Be sure to register an appropriate configuration and check for typos.' # $Name
-	'Invoke-DMDomainData.Script.NotFound.Error'                     = 'Critical error: Could not find a registered DomainData set with the name "{0}". Be sure to register an appropriate configuration and check for typos.' # $Name
+	'Invoke-DMAcl.MissingADObject'								    = 'The target object could not be found: {0}' # $testItem.Identity
+	'Invoke-DMAcl.NoAccess'										    = 'Failed to access Acl on {0}' # $testItem.Identity
+	'Invoke-DMAcl.OwnerNotResolved'								    = 'Was unable to resolve the current owner ({1}) of {0}' # $testItem.Identity, $testItem.ADObject.GetOwner([System.Security.Principal.SecurityIdentifier])
+	'Invoke-DMAcl.ShouldManage'									    = 'The ADObject {0} has no defined ACL state and should either be configured or removed' # $testItem.Identity
+	'Invoke-DMAcl.UpdatingInheritance'							    = 'Updating inheritance - Inheritance Disabled: {0}' # $testItem.Configuration.NoInheritance
+	'Invoke-DMAcl.UpdatingOwner'								    = 'Granting ownership to {0}' # ($testItem.Configuration.Owner | Resolve-String)
 	
-	'Invoke-DMDomainLevel.Raise.Level'                              = 'Raising domain level to {0}' # $testItem.Configuration.Level
+	'Invoke-DMDomainData.Invocation.Error'						    = 'An exception was thrown while executing the domain data script "{0}".' # $Name
+	'Invoke-DMDomainData.Invocation.Error.Terminate'			    = 'Critical Error: An exception was thrown while executing the domain data script "{0}".' # $Name
+	'Invoke-DMDomainData.Script.NotFound'						    = 'Could not find a registered DomainData set with the name "{0}". Be sure to register an appropriate configuration and check for typos.' # $Name
+	'Invoke-DMDomainData.Script.NotFound.Error'					    = 'Critical error: Could not find a registered DomainData set with the name "{0}". Be sure to register an appropriate configuration and check for typos.' # $Name
 	
-	'Invoke-DMGPLink.Delete.AllEnabled'                             = 'Removing all ({0}) policy links (all of which are enabled)' # $countActual
-	'Invoke-DMGPLink.New'                                           = 'Linking {0} group policies (all new links)' # $countConfigured
-	'Invoke-DMGPLink.New.GpoNotFound'                               = 'Unable to find Group POlicy Object: {0}' # (Resolve-String -Text $_.PolicyName)
-	'Invoke-DMGPLink.New.NewGPLinkString'                           = 'Finished gPLink string being applied to {0}: {1}' # $ADObject.DistinguishedName, $gpLinkString
-	'Invoke-DMGPLink.Update.AllEnabled'                             = 'Updating GPLink - {0} links configured, {1} links present, {2} links present that are not in configuration (All present and undesired links are enabled)' # $countConfigured, $countActual, $countNotInConfig
-	'Invoke-DMGPLink.Update.GpoNotFound'                            = 'Unable to find Group POlicy Object: {0}' # (Resolve-String -Text $_.PolicyName)
-	'Invoke-DMGPLink.Update.NewGPLinkString'                        = 'Finished gPLink string being applied to {0}: {1}' # $ADObject.DistinguishedName, $gpLinkString
+	'Invoke-DMDomainLevel.Raise.Level'							    = 'Raising domain level to {0}' # $testItem.Configuration.Level
 	
-	'Invoke-DMGPPermission.AD.Access.Error'                         = 'Error accessing Active Directory for {0} ({1})' # $testResult, $testResult.ADObject.DistinguishedName
-	'Invoke-DMGPPermission.AD.UpdatingPermission'                   = 'Updating {0} permission changes on the AD object' # $testResult.Changed.Count
-	'Invoke-DMGPPermission.Gpo.SyncingPermission'                   = 'Making {0} permission changes consistent through the GPO Api' # $testResult.Changed.Count
-	'Invoke-DMGPPermission.Invalid.Input'                           = 'The input object was not recognized as a valid test result for Group Policy Permissions: {0}' # $testResult
-	'Invoke-DMGPPermission.Result.Access.Error'                     = 'The test for {0} failed, due to access error during the test phase!' # $testResult.Identity
-	'Invoke-DMGPPermission.WinRM.Failed'                            = 'Failed to connect to {0}' # $computerName
-	'Invoke-DMGPPermission.AccessRule.Error'                        = 'Error creating accessrule for identity "{0}" of principal "{1}". Make sure the principal exists' # $change.Identity, $change.DisplayName
+	'Invoke-DMGPLink.Delete.AllEnabled'							    = 'Removing all ({0}) policy links (all of which are enabled)' # $countActual
+	'Invoke-DMGPLink.New'										    = 'Linking {0} group policies (all new links)' # $countConfigured
+	'Invoke-DMGPLink.New.GpoNotFound'							    = 'Unable to find Group POlicy Object: {0}' # (Resolve-String -Text $_.PolicyName)
+	'Invoke-DMGPLink.New.NewGPLinkString'						    = 'Finished gPLink string being applied to {0}: {1}' # $ADObject.DistinguishedName, $gpLinkString
+	'Invoke-DMGPLink.Update.AllEnabled'							    = 'Updating GPLink - {0} links configured, {1} links present, {2} links present that are not in configuration (All present and undesired links are enabled)' # $countConfigured, $countActual, $countNotInConfig
+	'Invoke-DMGPLink.Update.GpoNotFound'						    = 'Unable to find Group POlicy Object: {0}' # (Resolve-String -Text $_.PolicyName)
+	'Invoke-DMGPLink.Update.NewGPLinkString'					    = 'Finished gPLink string being applied to {0}: {1}' # $ADObject.DistinguishedName, $gpLinkString
 	
-	'Invoke-DMGroup.Group.Create'                                   = 'Creating active directory group' # 
-	'Invoke-DMGroup.Group.Create.OUExistsNot'                       = 'Cannot create group {1} : Path does not exist: {0}' # $targetOU, $testItem.Identity
-	'Invoke-DMGroup.Group.Delete'                                   = 'Deleting active directory group' # 
-	'Invoke-DMGroup.Group.InvalidScope'                             = 'Invalid scope defined for {0}: {1} is not a legal group scope.' # $testItem, $targetScope
-	'Invoke-DMGroup.Group.Move'                                     = 'Moving active directory group to {0}' # $targetOU
-	'Invoke-DMGroup.Group.MultipleOldGroups'                        = 'Cannot rename group to {0}: More than one group exists owning one of the previous names. Conflicting groups: {1}. Please investigate and manually resolve.' # $testItem.Identity, ($testItem.ADObject.Name -join ', ')
-	'Invoke-DMGroup.Group.Rename'                                   = 'Renaming active directory group to {0}' # (Resolve-String -Text $testItem.Configuration.Name)
-	'Invoke-DMGroup.Group.Update'                                   = 'Updating {0} on active directory group' # ($changes.Keys -join ", ")
-	'Invoke-DMGroup.Group.Update.Name'                              = 'Renaming to {0}' # (Resolve-String -Text $testItem.Configuration.Name)
-	'Invoke-DMGroup.Group.Update.OUExistsNot'                       = 'Cannot move active directory group {0} - OU does not exist: {1}' # $testItem.Identity, $targetOU
-	'Invoke-DMGroup.Group.Update.Scope'                             = 'Updating the group scope of {0} from {1} to {2}' # $testItem, $testItem.ADObject.GroupScope, $targetScope
+	'Invoke-DMGPPermission.AccessRule.Error'					    = 'Error creating accessrule for identity "{0}" of principal "{1}". Make sure the principal exists' # $change.Identity, $change.DisplayName
+	'Invoke-DMGPPermission.AD.Access.Error'						    = 'Error accessing Active Directory for {0} ({1})' # $testResult, $testResult.ADObject.DistinguishedName
+	'Invoke-DMGPPermission.AD.UpdatingPermission'				    = 'Updating {0} permission changes on the AD object' # $testResult.Changed.Count
+	'Invoke-DMGPPermission.Gpo.SyncingPermission'				    = 'Making {0} permission changes consistent through the GPO Api' # $testResult.Changed.Count
+	'Invoke-DMGPPermission.Invalid.Input'						    = 'The input object was not recognized as a valid test result for Group Policy Permissions: {0}' # $testResult
+	'Invoke-DMGPPermission.Result.Access.Error'					    = 'The test for {0} failed, due to access error during the test phase!' # $testResult.Identity
+	'Invoke-DMGPPermission.WinRM.Failed'						    = 'Failed to connect to {0}' # $computerName
 	
-	'Invoke-DMGroupMembership.GroupMember.Add'                      = 'Adding member to {0}' # $testItem.ADObject.Name
-	'Invoke-DMGroupMembership.GroupMember.Remove'                   = 'Removing member from {0}' # $testItem.ADObject.Name
-	'Invoke-DMGroupMembership.GroupMember.RemoveUnidentified'       = 'Removing unidentified foreign security principal from {0}' # $testItem.ADObject.Name
-	'Invoke-DMGroupMembership.Unidentified'                         = 'Could not identify current group member: {0}' # $testItem.Identity
-	'Invoke-DMGroupMembership.Unresolved'                           = 'Could not identify required group member: {0}' # $testItem.Identity
+	'Invoke-DMGroup.Group.Create'								    = 'Creating active directory group' # 
+	'Invoke-DMGroup.Group.Create.OUExistsNot'					    = 'Cannot create group {1} : Path does not exist: {0}' # $targetOU, $testItem.Identity
+	'Invoke-DMGroup.Group.Delete'								    = 'Deleting active directory group' # 
+	'Invoke-DMGroup.Group.InvalidScope'							    = 'Invalid scope defined for {0}: {1} is not a legal group scope.' # $testItem, $targetScope
+	'Invoke-DMGroup.Group.Move'									    = 'Moving active directory group to {0}' # $targetOU
+	'Invoke-DMGroup.Group.MultipleOldGroups'					    = 'Cannot rename group to {0}: More than one group exists owning one of the previous names. Conflicting groups: {1}. Please investigate and manually resolve.' # $testItem.Identity, ($testItem.ADObject.Name -join ', ')
+	'Invoke-DMGroup.Group.Rename'								    = 'Renaming active directory group to {0}' # (Resolve-String -Text $testItem.Configuration.Name)
+	'Invoke-DMGroup.Group.Update'								    = 'Updating {0} on active directory group' # ($changes.Keys -join ", ")
+	'Invoke-DMGroup.Group.Update.Name'							    = 'Renaming to {0}' # (Resolve-String -Text $testItem.Configuration.Name)
+	'Invoke-DMGroup.Group.Update.OUExistsNot'					    = 'Cannot move active directory group {0} - OU does not exist: {1}' # $testItem.Identity, $targetOU
+	'Invoke-DMGroup.Group.Update.Scope'							    = 'Updating the group scope of {0} from {1} to {2}' # $testItem, $testItem.ADObject.GroupScope, $targetScope
 	
-	'Invoke-DMGroupPolicy.Delete'                                   = 'Deleting group policy object: {0}.' # $testItem.Identity
-	'Invoke-DMGroupPolicy.Install.OnBadRegistry'                    = 'Re-applying GPO "{0}" after detecting a registry setting that is not as defined.' # $testItem.Identity
-	'Invoke-DMGroupPolicy.Install.OnConfigError'                    = 'Re-applying GPO "{0}" after failing to read its configuration' # $testItem.Identity
-	'Invoke-DMGroupPolicy.Install.OnManage'                         = 'Re-Applying GPO "{0}" for the first time to bring it under management' # $testItem.Identity
-	'Invoke-DMGroupPolicy.Install.OnModify'                         = 'GPO "{0}" was modified outside this system, re-applying GPO' # $testItem.Identity
-	'Invoke-DMGroupPolicy.Install.OnNew'                            = 'GPO "{0}" not found in AD, creating new GPO' # $testItem.Identity
-	'Invoke-DMGroupPolicy.Install.OnUpdate'                         = 'New GPO definition available, updating GPO "{0}"' # $testItem.Identity
-	'Invoke-DMGroupPolicy.Remote.WorkingDirectory.Failed'           = 'Failed to create working directory on {0}. This is required for importing GPOs' # $computerName
-	'Invoke-DMGroupPolicy.Skipping.InCriticalState'                 = 'Critical error validating {0}. The GPO will be skipped, please manually verify the GPO and bring it into a supportable state.' # $testItem.Identity
-	'Invoke-DMGroupPolicy.WinRM.Failed'                             = 'Failed to connect to "{0}" via WinRM/PowerShell Remoting.' # $computerName
+	'Invoke-DMGroupMembership.GroupMember.Add'					    = 'Adding member to {0}' # $testItem.ADObject.Name
+	'Invoke-DMGroupMembership.GroupMember.Remove'				    = 'Removing member from {0}' # $testItem.ADObject.Name
+	'Invoke-DMGroupMembership.GroupMember.RemoveUnidentified'	    = 'Removing unidentified foreign security principal from {0}' # $testItem.ADObject.Name
+	'Invoke-DMGroupMembership.Unidentified'						    = 'Could not identify current group member: {0}' # $testItem.Identity
+	'Invoke-DMGroupMembership.Unresolved'						    = 'Could not identify required group member: {0}' # $testItem.Identity
 	
-	'Invoke-DMObject.Object.Change'                                 = 'Updating the properties {0}' # ($testItem.Changed -join ", ")
-	'Invoke-DMObject.Object.Create'                                 = 'Creating {0} object in {1}' # $testItem.Configuration.ObjectClass, $testItem.Identity
+	'Invoke-DMGroupPolicy.Delete'								    = 'Deleting group policy object: {0}.' # $testItem.Identity
+	'Invoke-DMGroupPolicy.Install.OnBadRegistry'				    = 'Re-applying GPO "{0}" after detecting a registry setting that is not as defined.' # $testItem.Identity
+	'Invoke-DMGroupPolicy.Install.OnConfigError'				    = 'Re-applying GPO "{0}" after failing to read its configuration' # $testItem.Identity
+	'Invoke-DMGroupPolicy.Install.OnManage'						    = 'Re-Applying GPO "{0}" for the first time to bring it under management' # $testItem.Identity
+	'Invoke-DMGroupPolicy.Install.OnModify'						    = 'GPO "{0}" was modified outside this system, re-applying GPO' # $testItem.Identity
+	'Invoke-DMGroupPolicy.Install.OnNew'						    = 'GPO "{0}" not found in AD, creating new GPO' # $testItem.Identity
+	'Invoke-DMGroupPolicy.Install.OnUpdate'						    = 'New GPO definition available, updating GPO "{0}"' # $testItem.Identity
+	'Invoke-DMGroupPolicy.Remote.WorkingDirectory.Failed'		    = 'Failed to create working directory on {0}. This is required for importing GPOs' # $computerName
+	'Invoke-DMGroupPolicy.Skipping.InCriticalState'				    = 'Critical error validating {0}. The GPO will be skipped, please manually verify the GPO and bring it into a supportable state.' # $testItem.Identity
+	'Invoke-DMGroupPolicy.WinRM.Failed'							    = 'Failed to connect to "{0}" via WinRM/PowerShell Remoting.' # $computerName
 	
-	'Invoke-DMOrganizationalUnit.OU.Create'                         = 'Creating organizational unit' # 
-	'Invoke-DMOrganizationalUnit.OU.Create.OUExistsNot'             = 'Cannot create OU {1}, parent OU does not exist: {0}' # $targetOU, $testItem.Identity
-	'Invoke-DMOrganizationalUnit.OU.Delete'                         = 'Deleting organizational unit' # 
-	'Invoke-DMOrganizationalUnit.OU.Delete.HasChildren'             = 'Skipping the deletion of {0} - OU has {1} childitem(s) that would also be deleted. Please manually handle these before proceeding.' # $testItem.ADObject.DistinguishedName, ($childObjects | Measure-Object).Count
-	'Invoke-DMOrganizationalUnit.OU.Delete.NoAction'                = 'Skipping the deletion of {0} - OU deletion has been disabled' # $testItem.Identity
-	'Invoke-DMOrganizationalUnit.OU.MultipleOldOUs'                 = 'Cannot rename organizational unit to {0}: More than one organizational unit exists owning one of the previous names. Conflicting organizational unit: {1}. Please investigate and manually resolve.' # $testItem.Identity, ($testItem.ADObject.Name -join ', ')
-	'Invoke-DMOrganizationalUnit.OU.Rename'                         = 'Renaming organizational unit to {0}' # (Resolve-String -Text $testItem.Configuration.Name)
-	'Invoke-DMOrganizationalUnit.OU.Update'                         = 'Updating {0} on organizational unit' # ($changes.Keys -join ", ")
+	'Invoke-DMObject.Object.Change'								    = 'Updating the properties {0}' # ($testItem.Changed -join ", ")
+	'Invoke-DMObject.Object.Create'								    = 'Creating {0} object in {1}' # $testItem.Configuration.ObjectClass, $testItem.Identity
 	
-	'Invoke-DMPasswordPolicy.PSO.Create'                            = 'Creating new PSO object' # 
-	'Invoke-DMPasswordPolicy.PSO.Delete'                            = 'Deleting PSO object' # 
-	'Invoke-DMPasswordPolicy.PSO.Update'                            = 'Updating properties: {0}' # ($changes.Keys -join ", ")
-	'Invoke-DMPasswordPolicy.PSO.Update.GroupAssignment'            = 'Assigning PSO to {0}' # (Resolve-String -Text $testItem.Configuration.SubjectGroup)
+	'Invoke-DMOrganizationalUnit.OU.Create'						    = 'Creating organizational unit' # 
+	'Invoke-DMOrganizationalUnit.OU.Create.OUExistsNot'			    = 'Cannot create OU {1}, parent OU does not exist: {0}' # $targetOU, $testItem.Identity
+	'Invoke-DMOrganizationalUnit.OU.Delete'						    = 'Deleting organizational unit' # 
+	'Invoke-DMOrganizationalUnit.OU.Delete.HasChildren'			    = 'Skipping the deletion of {0} - OU has {1} childitem(s) that would also be deleted. Please manually handle these before proceeding.' # $testItem.ADObject.DistinguishedName, ($childObjects | Measure-Object).Count
+	'Invoke-DMOrganizationalUnit.OU.Delete.NoAction'			    = 'Skipping the deletion of {0} - OU deletion has been disabled' # $testItem.Identity
+	'Invoke-DMOrganizationalUnit.OU.MultipleOldOUs'				    = 'Cannot rename organizational unit to {0}: More than one organizational unit exists owning one of the previous names. Conflicting organizational unit: {1}. Please investigate and manually resolve.' # $testItem.Identity, ($testItem.ADObject.Name -join ', ')
+	'Invoke-DMOrganizationalUnit.OU.Rename'						    = 'Renaming organizational unit to {0}' # (Resolve-String -Text $testItem.Configuration.Name)
+	'Invoke-DMOrganizationalUnit.OU.Update'						    = 'Updating {0} on organizational unit' # ($changes.Keys -join ", ")
 	
-	'Invoke-DMUser.User.Create'                                     = 'Creating active directory user' # 
-	'Invoke-DMUser.User.Create.OUExistsNot'                         = 'Cannot create user {1} : Path does not exist: {0}' # $targetOU, $testItem.Identity
-	'Invoke-DMUser.User.Delete'                                     = 'Deleting active directory user' # 
-	'Invoke-DMUser.User.Move'                                       = 'Moving active directory user to {0}' # $targetOU
-	'Invoke-DMUser.User.MultipleOldUsers'                           = 'Cannot rename user to {0}: More than one user exists owning one of the previous names. Conflicting users: {1}. Please investigate and manually resolve.' # $testItem.Identity, ($testItem.ADObject.Name -join ', ')
-	'Invoke-DMUser.User.Rename'                                     = 'Renaming active directory user to {0}' # (Resolve-String -Text $testItem.Configuration.SamAccountName)
-	'Invoke-DMUser.User.Update'                                     = 'Updating {0} on active directory user' # ($changes.Keys -join ", ")
-	'Invoke-DMUser.User.Update.EnableDisable'                       = 'Changing user enabled state to: {0}' # $testItem.Configuration.Enabled
-	'Invoke-DMUser.User.Update.Name'                                = 'Renaming user to {0}' # (Resolve-String -Text $testItem.Configuration.Name)
-	'Invoke-DMUser.User.Update.OUExistsNot'                         = 'Cannot move active directory group {0} - user does not exist: {1}' # $testItem.Identity, $targetOU
-	'Invoke-DMUser.User.Update.PasswordNeverExpires'                = 'Changing user password non-expiration to: {0}' # $testItem.Configuration.PasswordNeverExpires
+	'Invoke-DMPasswordPolicy.PSO.Create'						    = 'Creating new PSO object' # 
+	'Invoke-DMPasswordPolicy.PSO.Delete'						    = 'Deleting PSO object' # 
+	'Invoke-DMPasswordPolicy.PSO.Update'						    = 'Updating properties: {0}' # ($changes.Keys -join ", ")
+	'Invoke-DMPasswordPolicy.PSO.Update.GroupAssignment'		    = 'Assigning PSO to {0}' # (Resolve-String -Text $testItem.Configuration.SubjectGroup)
 	
-	'Remove-GroupPolicy.Deleting'                                   = 'Deleting GPO: {0}' # $ADObject.DisplayName
-	'Remove-GroupPolicy.Deleting.Failed'                            = 'Failed to delete GPO: {0}' # $ADObject.DisplayName
+	'Invoke-DMServiceAccount.Computer.NotFound'					    = 'Error processing service account {1}: Cannot find computer {0}, will be unable to assign this access permission to the service account.' # $name, $resolvedName
+	'Invoke-DMServiceAccount.Computer.Optional.NotFound'		    = 'Error processing service account {1}: Cannot find computer {0}, will be unable to assign this access permission to the service account.' # $name, $resolvedName
+	'Invoke-DMServiceAccount.Creating'							    = 'Creating a new service account: {0}' # $testItem.Identity
+	'Invoke-DMServiceAccount.Deleting'							    = 'Deleting service account {0}' # $testItem.Identity
+	'Invoke-DMServiceAccount.Disabling'							    = 'Disabling service account {0}' # $testItem.Identity
+	'Invoke-DMServiceAccount.Enabling'							    = 'Enabling service account {0}' # $testItem.Identity
+	'Invoke-DMServiceAccount.Moving'							    = 'Moving service account {0} to {1}' # $testItem.Identity, $testItem.Changed.NewValue
+	'Invoke-DMServiceAccount.Updating'							    = 'Updating properties on service account {0}' # $testItem.Identity
+	'Invoke-DMServiceAccount.UpdatingPrincipal'					    = 'Updating principals allowed to access service account {0}' # $testItem.Identity
 	
-	'Resolve-ContentSearchBase.Exclude.NotFound'                    = 'Failed to find excluded ou/container: {0}' # $item.Name
-	'Resolve-ContentSearchBase.Include.NotFound'                    = 'Failed to find included ou/container: {0}' # $item.Name
-	'Resolve-ContentSearchBase.Searchbase.Found'                    = 'Resolved searchbase in {2}: {0} | {1}' # $searchBase.SearchScope, $searchBase.SearchBase, $script:domainContext.Fqdn
+	'Invoke-DMUser.User.Create'									    = 'Creating active directory user' # 
+	'Invoke-DMUser.User.Create.OUExistsNot'						    = 'Cannot create user {1} : Path does not exist: {0}' # $targetOU, $testItem.Identity
+	'Invoke-DMUser.User.Delete'									    = 'Deleting active directory user' # 
+	'Invoke-DMUser.User.Move'									    = 'Moving active directory user to {0}' # $targetOU
+	'Invoke-DMUser.User.MultipleOldUsers'						    = 'Cannot rename user to {0}: More than one user exists owning one of the previous names. Conflicting users: {1}. Please investigate and manually resolve.' # $testItem.Identity, ($testItem.ADObject.Name -join ', ')
+	'Invoke-DMUser.User.Rename'									    = 'Renaming active directory user to {0}' # (Resolve-String -Text $testItem.Configuration.SamAccountName)
+	'Invoke-DMUser.User.Update'									    = 'Updating {0} on active directory user' # ($changes.Keys -join ", ")
+	'Invoke-DMUser.User.Update.EnableDisable'					    = 'Changing user enabled state to: {0}' # $testItem.Configuration.Enabled
+	'Invoke-DMUser.User.Update.Name'							    = 'Renaming user to {0}' # (Resolve-String -Text $testItem.Configuration.Name)
+	'Invoke-DMUser.User.Update.OUExistsNot'						    = 'Cannot move active directory group {0} - user does not exist: {1}' # $testItem.Identity, $targetOU
+	'Invoke-DMUser.User.Update.PasswordNeverExpires'			    = 'Changing user password non-expiration to: {0}' # $testItem.Configuration.PasswordNeverExpires
 	
-	'Resolve-DMAccessRuleMode.PathResolution.Failed'                = 'Unable to resolve path: {0}' # $mode.Path
+	'Remove-GroupPolicy.Deleting'								    = 'Deleting GPO: {0}' # $ADObject.DisplayName
+	'Remove-GroupPolicy.Deleting.Failed'						    = 'Failed to delete GPO: {0}' # $ADObject.DisplayName
 	
-	'Resolve-Identity.ParentObject.NoSecurityPrincipal'             = 'Error processing parent of {0} : {1} of type {2} is no legal security principal and cannot be assigned permissions!' # $ADObject, $parentObject.Name, $parentObject.ObjectClass
+	'Resolve-ContentSearchBase.Exclude.NotFound'				    = 'Failed to find excluded ou/container: {0}' # $item.Name
+	'Resolve-ContentSearchBase.Include.NotFound'				    = 'Failed to find included ou/container: {0}' # $item.Name
+	'Resolve-ContentSearchBase.Searchbase.Found'				    = 'Resolved searchbase in {2}: {0} | {1}' # $searchBase.SearchScope, $searchBase.SearchBase, $script:domainContext.Fqdn
 	
-	'Resolve-PolicyRevision.Result.ErrorOnConfigImport'             = 'Failed to read configuration for {0}: {1}' # $Policy.DisplayName, $result.Error.Exception.Message
-	'Resolve-PolicyRevision.Result.PolicyError'                     = 'Policy object not found in filesystem: {0}. Check existence and permissions!' # $Policy.DisplayName
-	'Resolve-PolicyRevision.Result.Result.SuccessNotYetManaged'     = 'Policy found: {0}. Has not yet been managed, will need to be overwritten.' # $Policy.DisplayName
-	'Resolve-PolicyRevision.Result.Success'                         = 'Found GPO: {0}. Last export ID: {1}. Last updated on {2}' # $Policy.DisplayName, $result.ExportID, $result.Timestamp
+	'Resolve-DMAccessRuleMode.PathResolution.Failed'			    = 'Unable to resolve path: {0}' # $mode.Path
 	
-	'Set-DMRedForestContext.Connection.Failed'                      = 'Failed to connect to {0}' # $Server
+	'Resolve-Identity.ParentObject.NoSecurityPrincipal'			    = 'Error processing parent of {0} : {1} of type {2} is no legal security principal and cannot be assigned permissions!' # $ADObject, $parentObject.Name, $parentObject.ObjectClass
 	
-	'Test-DMAccessRule.DefaultPermission.Failed'                    = 'Failed to retrieve default permissions from Schema when connecting to {0}' # $Server
-	'Test-DMAccessRule.NoAccess'                                    = 'Failed to access {0}' # $resolvedPath
+	'Resolve-PolicyRevision.Result.ErrorOnConfigImport'			    = 'Failed to read configuration for {0}: {1}' # $Policy.DisplayName, $result.Error.Exception.Message
+	'Resolve-PolicyRevision.Result.PolicyError'					    = 'Policy object not found in filesystem: {0}. Check existence and permissions!' # $Policy.DisplayName
+	'Resolve-PolicyRevision.Result.Result.SuccessNotYetManaged'	    = 'Policy found: {0}. Has not yet been managed, will need to be overwritten.' # $Policy.DisplayName
+	'Resolve-PolicyRevision.Result.Success'						    = 'Found GPO: {0}. Last export ID: {1}. Last updated on {2}' # $Policy.DisplayName, $result.ExportID, $result.Timestamp
 	
-	'Test-DMAcl.ADObjectNotFound'                                   = 'The target object could not be found: {0}' # $resolvedPath
-	'Test-DMAcl.NoAccess'                                           = 'Failed to access Acl on {0}' # $resolvedPath
+	'Set-DMRedForestContext.Connection.Failed'					    = 'Failed to connect to {0}' # $Server
 	
-	'Test-DMGPLink.OUNotFound'                                      = 'Failed to find the configured OU: {0} - Please validate your OU configuration and bring your OU estate into the desired state first!' # $resolvedName
+	'Test-DMAccessRule.DefaultPermission.Failed'				    = 'Failed to retrieve default permissions from Schema when connecting to {0}' # $Server
+	'Test-DMAccessRule.NoAccess'								    = 'Failed to access {0}' # $resolvedPath
+	
+	'Test-DMAcl.ADObjectNotFound'								    = 'The target object could not be found: {0}' # $resolvedPath
+	'Test-DMAcl.NoAccess'										    = 'Failed to access Acl on {0}' # $resolvedPath
+	
+	'Test-DMGPLink.OUNotFound'									    = 'Failed to find the configured OU: {0} - Please validate your OU configuration and bring your OU estate into the desired state first!' # $ouDatum.OrganizationalUnit
 	
 	'Test-DMGPPermission.Filter.Path.DoesNotExist.SilentlyContinue' = 'The searchbase for the filter condition {0} could not be found. This however was defined as optional and is not an error: {1}' # $Condition.Name, $searchBase
-	'Test-DMGPPermission.Filter.Path.DoesNotExist.Stop'             = 'The searchbase {1} for the filter condition {0} could not be found. A consistent picture of the desired permission configuration is impossible, terminating!' # $searchBase
-	'Test-DMGPPermission.Filter.Result'                             = 'Resolved filter condition {0} to GPOs: {1}' # $key, ($filterToGPOMapping[$key].DisplayName -join ', ')
-	'Test-DMGPPermission.Identity.Resolution.Error'                 = 'Failed to resolve the identity of an intended privilege-holder on {0}. Cancelling the processing for this GPO, as correct access configuration is not assured.' # $adObject.DisplayName
-	'Test-DMGPPermission.Validate.MissingFilterConditions'          = 'Critical configuration error: Not all referenced Group Policy Permission filter-conditions were defined. Undefined conditions: {0}' # ($missingConditions -join ", ")
-	'Test-DMGPPermission.WinRM.Failed'                              = 'Failed to connect to {0}' # $computerName
+	'Test-DMGPPermission.Filter.Path.DoesNotExist.Stop'			    = 'The searchbase {1} for the filter condition {0} could not be found. A consistent picture of the desired permission configuration is impossible, terminating!' # $searchBase
+	'Test-DMGPPermission.Filter.Result'							    = 'Resolved filter condition {0} to GPOs: {1}' # $key, ($filterToGPOMapping[$key].DisplayName -join ', ')
+	'Test-DMGPPermission.Identity.Resolution.Error'				    = 'Failed to resolve the identity of an intended privilege-holder on {0}. Cancelling the processing for this GPO, as correct access configuration is not assured.' # $adObject.DisplayName
+	'Test-DMGPPermission.Validate.MissingFilterConditions'		    = 'Critical configuration error: Not all referenced Group Policy Permission filter-conditions were defined. Undefined conditions: {0}' # ($missingConditions -join ", ")
+	'Test-DMGPPermission.WinRM.Failed'							    = 'Failed to connect to {0}' # $computerName
 	
-	'Test-DMGPRegistrySetting.TestResult'                           = 'Finished testing GP Registry settings against {0}. Success: {1} | Status: {2}' # $resolvedName, $result.Success, $result.Status
-	'Test-DMGPRegistrySetting.WinRM.Failed'                         = 'Failed to connect to {0}' # $parameters.Server
+	'Test-DMGPRegistrySetting.TestResult'						    = 'Finished testing GP Registry settings against {0}. Success: {1} | Status: {2}' # $resolvedName, $result.Success, $result.Status
+	'Test-DMGPRegistrySetting.WinRM.Failed'						    = 'Failed to connect to {0}' # $parameters.Server
 	
-	'Test-DMGroupMembership.Assignment.Resolve.Connect'             = 'Failed to resolve {2} {1} - Could not connect to {0}' # (Resolve-String -Text $assignment.Domain), (Resolve-String -Text $assignment.Name), $assignment.ItemType
-	'Test-DMGroupMembership.Assignment.Resolve.NotFound'            = 'Successfully queried domain "{0}", but the member {1} of type {2} could not be found' # (Resolve-String -Text $assignment.Domain), (Resolve-String -Text $assignment.Name), $assignment.ItemType
-	'Test-DMGroupMembership.Group.Access.Failed'                    = 'Failed to access group {0} in target domain, cannot compare its members with the configured state.' # $resolvedGroupName
+	'Test-DMGroupMembership.Assignment.Resolve.Connect'			    = 'Failed to resolve {2} {1} - Could not connect to {0}' # (Resolve-String -Text $assignment.Domain), (Resolve-String -Text $assignment.Name), $assignment.ItemType
+	'Test-DMGroupMembership.Assignment.Resolve.NotFound'		    = 'Successfully queried domain "{0}", but the member {1} of type {2} could not be found' # (Resolve-String -Text $assignment.Domain), (Resolve-String -Text $assignment.Name), $assignment.ItemType
+	'Test-DMGroupMembership.Group.Access.Failed'				    = 'Failed to access group {0} in target domain, cannot compare its members with the configured state.' # $resolvedGroupName
 	
-	'Test-DMGroupPolicy.ADObjectAccess.Failed'                      = 'Failed to access GPO active directory object for: {0}' # $managedPolicy.DistinguishedName
-	'Test-DMGroupPolicy.DomainData.Failed'                          = 'Failed to retrieve the domain-specific data for the following sources: {0}' # ($domainDataNames -join ",")
-	'Test-DMGroupPolicy.PolicyRevision.Lookup.Failed'               = 'Failed to resolve GPO in AD: {0}' # $managedPolicies.DisplayName
-	'Test-DMGroupPolicy.WinRM.Failed'                               = 'Failed to connect to "{0}" via WinRM/PowerShell Remoting.' # $computerName
+	'Test-DMGroupPolicy.ADObjectAccess.Failed'					    = 'Failed to access GPO active directory object for: {0}' # $managedPolicy.DistinguishedName
+	'Test-DMGroupPolicy.DomainData.Failed'						    = 'Failed to retrieve the domain-specific data for the following sources: {0}' # ($domainDataNames -join ",")
+	'Test-DMGroupPolicy.PolicyRevision.Lookup.Failed'			    = 'Failed to resolve GPO in AD: {0}' # $managedPolicies.DisplayName
+	'Test-DMGroupPolicy.WinRM.Failed'							    = 'Failed to connect to "{0}" via WinRM/PowerShell Remoting.' # $computerName
 	
-	'Test-DMObject.ADObject.Access.Error'                           = 'Failed to access {0} while retrieving {1}' # $resolvedPath, ($objectDefinition.Attributes.Keys -join ",")
-	'Test-DMObject.ADObject.Access.Error2'                          = 'Failed to access {0}' # $resolvedPath
+	'Test-DMObject.ADObject.Access.Error'						    = 'Failed to access {0} while retrieving {1}' # $resolvedPath, ($objectDefinition.Attributes.Keys -join ",")
+	'Test-DMObject.ADObject.Access.Error2'						    = 'Failed to access {0}' # $resolvedPath
 	
-	'Test-DMPasswordPolicy.SubjectGroup.NotFound'                   = 'Failed to find the group {0}, which should be granted permission to the Finegrained Password Policy {1}' # $groupName, $resolvedName
+	'Test-DMPasswordPolicy.SubjectGroup.NotFound'				    = 'Failed to find the group {0}, which should be granted permission to the Finegrained Password Policy {1}' # $groupName, $resolvedName
 	
-	'Validate.DomainData.Pattern'                                   = 'Invalid input: {0}. A domain data name must only consist of numbers, letters and underscore.' # <user input>, <validation item>
-	'Validate.GPPermissionFilter'                                   = 'Invalid GP Permission filter: {0}' # <user input>, <validation item>
-	'Validate.GPPermissionFilter.InvalidIdentifiers'                = 'Invalid filter elements (filter names): {1}. Filters can only consist of letters, numbers and underscore. Filter: {0}' # $_, ($invalidIdentifiers -join ', ')
-	'Validate.GPPermissionFilter.InvalidParameters'                 = 'Invalid filter elements (parameters): {1}. Only the four basic logical parameters are allowed: -and, -or, -not, -xor! Filter: {0}' # $_, ($invalidParameters -join ', ')
-	'Validate.GPPermissionFilter.InvalidTokenType'                  = 'Invalid filter element types: {1}. Only parenthesis, filter names and logical operators are allowed! Filter: {0}' # $_, ($invalidTokenTypes -join ', ')
-	'Validate.GPPermissionFilter.SyntaxError'                       = 'General syntax error in your filter string: {0}' # $_
-	'Validate.Identity'                                             = 'Invalid identity: {0} - Either specify a SID, a name in the format "<domain>\<name>" or in the format "<name>@<domainfqdn>"' # <user input>, <validation item>
-	'Validate.Name.Pattern'                                         = 'Invalid input: {0}. The name tag must start with a "%", end in a "%" and contain only letters, underscore and numbers inbetween.' # <user input>, <validation item>
-	'Validate.PermissionFilterName'                                 = 'Invalid input: {0}. GP Permission Filter names may only consist of letters, numbers and underscore characters.' # <user input>, <validation item>
-	'Validate.TypeName.AccessRule.Failed'                           = 'The input object {0} could not be verified as a "DomainManagement.AccessRule" object.' # <user input>, <validation item>
+	'Test-DMServiceAccount.Computer.NotFound'					    = 'Error processing service account {1}: Cannot find computer {0}, will be unable to assign this access permission to the service account.' # $name, $resolvedName
+	'Test-DMServiceAccount.Computer.Optional.NotFound'			    = 'Error processing service account {1}: Cannot find computer {0}, will be unable to assign this access permission to the service account.' # $name, $resolvedName
+	
+	'Validate.DomainData.Pattern'								    = 'Invalid input: {0}. A domain data name must only consist of numbers, letters and underscore.' # <user input>, <validation item>
+	'Validate.GPPermissionFilter'								    = 'Invalid GP Permission filter: {0}' # <user input>, <validation item>
+	'Validate.GPPermissionFilter.InvalidIdentifiers'			    = 'Invalid filter elements (filter names): {1}. Filters can only consist of letters, numbers and underscore. Filter: {0}' # $_, ($invalidIdentifiers -join ', ')
+	'Validate.GPPermissionFilter.InvalidParameters'				    = 'Invalid filter elements (parameters): {1}. Only the four basic logical parameters are allowed: -and, -or, -not, -xor! Filter: {0}' # $_, ($invalidParameters -join ', ')
+	'Validate.GPPermissionFilter.InvalidTokenType'				    = 'Invalid filter element types: {1}. Only parenthesis, filter names and logical operators are allowed! Filter: {0}' # $_, ($invalidTokenTypes -join ', ')
+	'Validate.GPPermissionFilter.SyntaxError'					    = 'General syntax error in your filter string: {0}' # $_
+	'Validate.Identity'											    = 'Invalid identity: {0} - Either specify a SID, a name in the format "<domain>\<name>" or in the format "<name>@<domainfqdn>"' # <user input>, <validation item>
+	'Validate.Name.Pattern'										    = 'Invalid input: {0}. The name tag must start with a "%", end in a "%" and contain only letters, underscore and numbers inbetween.' # <user input>, <validation item>
+	'Validate.PermissionFilterName'								    = 'Invalid input: {0}. GP Permission Filter names may only consist of letters, numbers and underscore characters.' # <user input>, <validation item>
+	'Validate.TypeName.AccessRule.Failed'						    = 'The input object {0} could not be verified as a "DomainManagement.AccessRule" object.' # <user input>, <validation item>
 }

--- a/DomainManagement/functions/groupmemberships/Register-DMGroupMembership.ps1
+++ b/DomainManagement/functions/groupmemberships/Register-DMGroupMembership.ps1
@@ -64,7 +64,7 @@
 		$Domain,
 		
 		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Entry')]
-		[ValidateSet('User', 'Group', 'foreignSecurityPrincipal')]
+		[ValidateSet('User', 'Group', 'foreignSecurityPrincipal', 'Computer')]
 		[string]
 		$ItemType,
 		

--- a/DomainManagement/functions/groupmemberships/Unregister-DMGroupMembership.ps1
+++ b/DomainManagement/functions/groupmemberships/Unregister-DMGroupMembership.ps1
@@ -28,7 +28,7 @@
 		$Name,
 
 		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
-		[ValidateSet('User', 'Group', 'foreignSecurityPrincipal', '<Empty>')]
+		[ValidateSet('User', 'Group', 'foreignSecurityPrincipal', 'Computer', '<Empty>')]
 		[string]
 		$ItemType,
 

--- a/DomainManagement/functions/objectcategories/Find-DMObjectCategoryItem.ps1
+++ b/DomainManagement/functions/objectcategories/Find-DMObjectCategoryItem.ps1
@@ -1,0 +1,81 @@
+﻿function Find-DMObjectCategoryItem {
+<#
+	.SYNOPSIS
+		Searches for items that are part of an object category.
+	
+	.DESCRIPTION
+		Searches for items that are part of an object category.
+		Caution: A combination of inefficient filters and large scope can lead to significant performance delays in large environments!
+	
+	.PARAMETER Name
+		The name of the object category to search items for.
+	
+	.PARAMETER Property
+		Properties to include when retrieving matching items.
+		Ensure the property is legal for all potential matches.
+	
+	.PARAMETER Server
+		The server / domain to work with.
+	
+	.PARAMETER Credential
+		The credentials to use for this operation.
+	
+	.PARAMETER EnableException
+		This parameters disables user-friendly warnings and enables the throwing of exceptions.
+		This is less user friendly, but allows catching exceptions in calling scripts.
+	
+	.EXAMPLE
+		PS C:\> Find-DMObjectCategoryItem -Name 'CAServer'
+	
+		Find all objects that are part of the CAServer category.
+#>
+	[CmdletBinding()]
+	param (
+		[Parameter(Mandatory = $true)]
+		[string]
+		$Name,
+		
+		[string[]]
+		$Property,
+		
+		[PSFComputer]
+		$Server,
+		
+		[PSCredential]
+		$Credential,
+		
+		[switch]
+		$EnableException
+	)
+	
+	begin {
+		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
+		$parameters['Debug'] = $false
+	}
+	process {
+		$category = $script:objectCategories[$Name]
+		if (-not $category) {
+			Stop-PSFFunction -String 'Find-DMObjectCategoryItem.Category.NotFound' -StringValues $Name -EnableException $EnableException -Cmdlet $PSCmdlet
+			return
+		}
+		
+		$searchBase = Resolve-String -Text $category.SearchBase @parameters
+		if ($category.LdapFilter) {
+			$filter = '(&(objectClass={0})({1}))' -f $category.ObjectClass, (Resolve-String -Text $category.LdapFilter @parameters)
+			if ($Property) { $parameters.Properties = $Property }
+			try { Get-ADObject @parameters -LDAPFilter $filter -SearchBase $searchBase -SearchScope $category.SearchScope -ErrorAction Stop }
+			catch {
+				Stop-PSFFunction -String 'Find-DMObjectCategoryItem.ADError' -StringValues $Name -EnableException $EnableException -Cmdlet $PSCmdlet
+				return
+			}
+		}
+		else {
+			if ($Property) { $parameters.Properties = $Property }
+			try { Get-ADObject @parameters -Filter $category.Filter -SearchBase $searchBase -SearchScope $category.SearchScope -ErrorAction Stop }
+			catch {
+				Stop-PSFFunction -String 'Find-DMObjectCategoryItem.ADError' -StringValues $Name -EnableException $EnableException -Cmdlet $PSCmdlet
+				return
+			}
+		}
+	}
+}

--- a/DomainManagement/functions/objectcategories/Register-DMObjectCategory.ps1
+++ b/DomainManagement/functions/objectcategories/Register-DMObjectCategory.ps1
@@ -46,6 +46,11 @@
 		- Subtree: All items under the searchbase. (default)
 		- OneLevel: All items directly under the searchbase.
 		- Base: Only the searchbase itself is inspected.
+
+	.PARAMETER ContextName
+		The name of the context defining the setting.
+		This allows determining the configuration set that provided this setting.
+		Used by the ADMF, available to any other configuration management solution.
 	
 	.EXAMPLE
 		PS C:\> Register-DMObjectCategory -Name DomainController -ObjectClass computer -Property PrimaryGroupID -TestScript { $args[0].PrimaryGroupID -eq 516 } -LDAPFilter '(&(objectCategory=computer)(primaryGroupID=516))'
@@ -85,7 +90,10 @@
 		[Parameter(ValueFromPipelineByPropertyName = $true)]
 		[ValidateSet('Subtree', 'OneLevel', 'Base')]
 		[string]
-		$SearchScope = 'Subtree'
+		$SearchScope = 'Subtree',
+		
+		[string]
+		$ContextName = '<Undefined>'
 	)
 	
 	process
@@ -99,6 +107,7 @@
 			LdapFilter  = $LdapFilter
 			SearchBase  = $SearchBase
 			SearchScope = $SearchScope
+			ContextName = $ContextName
 		}
 	}
 }

--- a/DomainManagement/functions/objectcategories/Register-DMObjectCategory.ps1
+++ b/DomainManagement/functions/objectcategories/Register-DMObjectCategory.ps1
@@ -1,6 +1,6 @@
 ﻿function Register-DMObjectCategory
 {
-	<#
+<#
 	.SYNOPSIS
 		Registers a new object category.
 	
@@ -9,7 +9,7 @@
 		Object categories are a way to apply settings to a type of object based on a ruleset / filterset.
 		For example, by registering an object category "Domain Controllers" (with appropriate filters / conditions),
 		it becomes possible to define access rules that apply to all domain controllers, but not all computers.
-
+		
 		Note: Not all setting types support categories yet.
 	
 	.PARAMETER Name
@@ -35,47 +35,70 @@
 	.PARAMETER LdapFilter
 		An LDAP filter used to find all objects in AD that match this category.
 	
+	.PARAMETER SearchBase
+		The path under which to look for objects of this category.
+		Defaults to domain wide.
+		Supports string resolution.
+	
+	.PARAMETER SearchScope
+		How deep to search for objects of this category under the chosen searchbase.
+		Supported Values:
+		- Subtree: All items under the searchbase. (default)
+		- OneLevel: All items directly under the searchbase.
+		- Base: Only the searchbase itself is inspected.
+	
 	.EXAMPLE
 		PS C:\> Register-DMObjectCategory -Name DomainController -ObjectClass computer -Property PrimaryGroupID -TestScript { $args[0].PrimaryGroupID -eq 516 } -LDAPFilter '(&(objectCategory=computer)(primaryGroupID=516))'
-
+		
 		Registers an object category applying to all domain controller's computer object in AD.
-	#>
+#>
 	[CmdletBinding(DefaultParameterSetName = 'Filter')]
-	Param (
+	param (
 		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
 		[string]
 		$Name,
-
+		
 		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
 		[string]
 		$ObjectClass,
-
+		
 		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
 		[string[]]
 		$Property,
-
+		
 		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
 		[scriptblock]
 		$TestScript,
-
+		
 		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Filter')]
 		[string]
 		$Filter,
-
+		
 		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'LdapFilter')]
 		[string]
-		$LdapFilter
+		$LdapFilter,
+		
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
+		[string]
+		$SearchBase = '%DomainDN%',
+		
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
+		[ValidateSet('Subtree', 'OneLevel', 'Base')]
+		[string]
+		$SearchScope = 'Subtree'
 	)
 	
 	process
 	{
 		$script:objectCategories[$Name] = [PSCustomObject]@{
-			Name = $Name
+			Name	    = $Name
 			ObjectClass = $ObjectClass
-			Property = $Property
-			TestScript = $TestScript
-			Filter = $Filter
-			LdapFilter = $LdapFilter
+			Property    = $Property
+			TestScript  = $TestScript
+			Filter	    = $Filter
+			LdapFilter  = $LdapFilter
+			SearchBase  = $SearchBase
+			SearchScope = $SearchScope
 		}
 	}
 }

--- a/DomainManagement/functions/organizationalunits/Invoke-DMOrganizationalUnit.ps1
+++ b/DomainManagement/functions/organizationalunits/Invoke-DMOrganizationalUnit.ps1
@@ -88,7 +88,7 @@
 			}
 			
 			switch ($testItem.Type) {
-				'ShouldDelete' {
+				'Delete' {
 					if (-not $Delete) {
 						Write-PSFMessage -String 'Invoke-DMOrganizationalUnit.OU.Delete.NoAction' -StringValues $testItem.Identity -Target $testItem
 						continue main
@@ -108,7 +108,7 @@
 						Remove-ADOrganizationalUnit @parameters -Identity $testItem.ADObject.ObjectGUID -ErrorAction Stop -Confirm:$false
 					} -EnableException $EnableException.ToBool() -PSCmdlet $PSCmdlet -Continue
 				}
-				'ConfigurationOnly' {
+				'Create' {
 					$targetOU = Resolve-String -Text $testItem.Configuration.Path
 					try { $null = Get-ADObject @parameters -Identity $targetOU -ErrorAction Stop }
 					catch { Stop-PSFFunction -String 'Invoke-DMOrganizationalUnit.OU.Create.OUExistsNot' -StringValues $targetOU, $testItem.Identity -Target $testItem -EnableException $EnableException -Continue -ContinueLabel main }

--- a/DomainManagement/functions/organizationalunits/Register-DMOrganizationalUnit.ps1
+++ b/DomainManagement/functions/organizationalunits/Register-DMOrganizationalUnit.ps1
@@ -1,5 +1,4 @@
-﻿function Register-DMOrganizationalUnit
-{
+﻿function Register-DMOrganizationalUnit {
 	<#
 	.SYNOPSIS
 		Registers an organizational unit, defining it as a desired state.
@@ -18,6 +17,10 @@
 	.PARAMETER Path
 		The path to where the OU should be.
 		Subject to string insertion.
+
+	.PARAMETER Optional
+		By default, organizational units must exist if defined.
+		Setting this to true makes them optional instead - they will not be created but are tolerated if they exist.
 	
 	.PARAMETER OldNames
 		Previous names the OU had.
@@ -47,6 +50,10 @@
 		[string]
 		$Path,
 
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
+		[bool]
+		$Optional,
+
 		[string[]]
 		$OldNames = @(),
 
@@ -54,17 +61,17 @@
 		$Present = $true
 	)
 	
-	process
-	{
+	process {
 		$distinguishedName = 'OU={0},{1}' -f $Name, $Path
 		$script:organizationalUnits[$distinguishedName] = [PSCustomObject]@{
-			PSTypeName = 'DomainManagement.OrganizationalUnit'
+			PSTypeName        = 'DomainManagement.OrganizationalUnit'
 			DistinguishedName = $distinguishedName
-			Name = $Name
-			Description = $Description
-			Path = $Path
-			OldNames = $OldNames
-			Present = $Present
+			Name              = $Name
+			Description       = $Description
+			Path              = $Path
+			Optional          = $Optional
+			OldNames          = $OldNames
+			Present           = $Present
 		}
 	}
 }

--- a/DomainManagement/functions/organizationalunits/Test-DMOrganizationalUnit.ps1
+++ b/DomainManagement/functions/organizationalunits/Test-DMOrganizationalUnit.ps1
@@ -51,7 +51,7 @@
 
 			if (-not $ouDefinition.Present) {
 				if ($adObject = Get-ADOrganizationalUnit @parameters -LDAPFilter "(distinguishedName=$resolvedDN)" -Properties Description, nTSecurityDescriptor) {
-					New-TestResult @resultDefaults -Type ShouldDelete -ADObject $adObject
+					New-TestResult @resultDefaults -Type Delete -ADObject $adObject
 				}
 				continue main
 			}
@@ -68,7 +68,9 @@
 					#region Case: No old version present
 					0
 					{
-						New-TestResult @resultDefaults -Type ConfigurationOnly
+						if (-not $ouDefinition.Optional) {
+							New-TestResult @resultDefaults -Type Create
+						}
 						continue main
 					}
 					#endregion Case: No old version present
@@ -118,7 +120,7 @@
 		foreach ($existingOU in $foundOUs) {
 			if ($existingOU.DistinguishedName -in $resolvedConfiguredNames) { continue } # Ignore configured OUs - they were previously configured for moving them, if they should not be in these containers
 			
-			New-TestResult @resultDefaults -Type ShouldDelete -ADObject $existingOU -Identity $existingOU.Name
+			New-TestResult @resultDefaults -Type Delete -ADObject $existingOU -Identity $existingOU.Name
 		}
 		#endregion Process Managed Containers
 	}

--- a/DomainManagement/functions/serviceaccounts/Get-DMServiceAccount.ps1
+++ b/DomainManagement/functions/serviceaccounts/Get-DMServiceAccount.ps1
@@ -1,0 +1,28 @@
+﻿function Get-DMServiceAccount
+{
+<#
+	.SYNOPSIS
+		List the configured service accounts.
+	
+	.DESCRIPTION
+		List the configured service accounts.
+	
+	.PARAMETER Name
+		Name to filter by.
+		Defaults to '*'
+	
+	.EXAMPLE
+		PS C:\> Get-DMServiceAccount
+	
+		List all configured service accounts.
+#>
+	[CmdletBinding()]
+	Param (
+		[string]
+		$Name = '*'
+	)
+	process
+	{
+		($script:serviceAccounts.Values) | Where-Object Name -like $Name
+	}
+}

--- a/DomainManagement/functions/serviceaccounts/Invoke-DMServiceAccount.ps1
+++ b/DomainManagement/functions/serviceaccounts/Invoke-DMServiceAccount.ps1
@@ -1,0 +1,235 @@
+﻿function Invoke-DMServiceAccount {
+<#
+	.SYNOPSIS
+		Applies the desired state of Service Accounts to the target domain.
+	
+	.DESCRIPTION
+		Applies the desired state of Service Accounts to the target domain.
+		Use Register-DMServiceAccount to define the desired state.
+	
+	.PARAMETER InputObject
+		Individual test results to apply.
+		Use Test-DMServiceAccount to generate these test result objects.
+		If none are specified, it will instead execute its own test and apply all test results.
+	
+	.PARAMETER Server
+		The server / domain to work with.
+		
+	.PARAMETER Credential
+		The credentials to use for this operation.
+	
+	.PARAMETER EnableException
+		This parameters disables user-friendly warnings and enables the throwing of exceptions.
+		This is less user friendly, but allows catching exceptions in calling scripts.
+	
+	.PARAMETER Confirm
+		If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
+	
+	.PARAMETER WhatIf
+		If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
+	
+	.EXAMPLE
+		PS C:\> Invoke-DMServiceAccount -Server fabrikam.org
+	
+		Brings the fabrikam.org domain into compliance with the defined service account configuration.
+#>
+	[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
+	param (
+		[Parameter(ValueFromPipeline = $true)]
+		$InputObject,
+		
+		[PSFComputer]
+		$Server,
+		
+		[PSCredential]
+		$Credential,
+		
+		[switch]
+		$EnableException
+	)
+	
+	begin {
+		#region Utility Functions
+		function Get-ObjectCategoryContent {
+			[CmdletBinding()]
+			param (
+				[System.Collections.Hashtable]
+				$Categories,
+				
+				[string]
+				$Name,
+				
+				[System.Collections.Hashtable]
+				$Parameters
+			)
+			
+			if (-not $Categories.ContainsKey($Name)) {
+				$Categories[$Name] = (Find-DMObjectCategoryItem -Name $Name @parameters -Property SamAccountName).SamAccountName
+			}
+			$Categories[$Name]
+		}
+		
+		function New-ServiceAccount {
+			[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
+			[CmdletBinding()]
+			param (
+				$TestItem,
+				
+				[System.Collections.Hashtable]
+				$Parameters,
+				
+				[System.Collections.Hashtable]
+				$Categories
+			)
+			
+			$resolvedPath = $TestItem.Configuration.Path | Resolve-String @parameters
+			
+			$newParam = $Parameters.Clone()
+			$newParam += @{
+				Name = $TestItem.Configuration.Name | Resolve-String @parameters
+				DNSHostName = $TestItem.Configuration.DNSHostName | Resolve-String @parameters
+				Description = $TestItem.Configuration.Description | Resolve-String @parameters
+			}
+			if ($TestItem.Configuration.ServicePrincipalName) { $newParam.ServicePrincipalNames = $TestItem.Configuration.ServicePrincipalName | Resolve-String @parameters }
+			if ($TestItem.Configuration.DisplayName) { $newParam.DisplayName = $TestItem.Configuration.DisplayName | Resolve-String @parameters }
+			if ($TestItem.Configuration.Attributes) { $newParam.OtherAttributes = $TestItem.Configuration.Attributes | ConvertTo-PSFHashtable }
+			
+			#region Calculate desired principals
+			$desiredPrincipals = @()
+			
+			foreach ($category in $TestItem.Configuration.ObjectCategory) {
+				Get-ObjectCategoryContent -Categories $Categories -Name $category -Parameters $Parameters | ForEach-Object {
+					$desiredPrincipals += $_
+				}
+			}
+			
+			# Direct Assignment
+			foreach ($name in $TestItem.Configuration.ComputerName) {
+				if ($name -notlike '*$') { $name = "$($name)$" }
+				try {
+					$null = Get-ADComputer -Identity $name -ErrorAction Stop
+					$desiredPrincipals += $name
+				}
+				catch {
+					Write-PSFMessage -Level Warning -String 'Invoke-DMServiceAccount.Computer.NotFound' -StringValues $name, $resolvedName -Target $TestItem.Configuration -Tag error, failed, serviceaccount, computer
+					continue
+				}
+			}
+			
+			# Optional Direct Assignment
+			foreach ($name in $TestItem.Configuration.ComputerNameOptional) {
+				if ($name -notlike '*$') { $name = "$($name)$" }
+				try {
+					$null = Get-ADComputer -Identity $name -ErrorAction Stop
+					$desiredPrincipals += $name
+				}
+				catch {
+					Write-PSFMessage -Level Verbose -String 'Invoke-DMServiceAccount.Computer.Optional.NotFound' -StringValues $name, $resolvedName -Target $TestItem.Configuration -Tag error, failed, serviceaccount, computer
+					continue
+				}
+			}
+			if ($desiredPrincipals) {
+				$newParam.PrincipalsAllowedToRetrieveManagedPassword = $desiredPrincipals
+			}
+			#endregion Calculate desired principals
+			
+			New-ADServiceAccount @newParam -ErrorAction Stop -Confirm:$false -Path $resolvedPath
+		}
+		
+		function Set-ServiceAccount {
+			[CmdletBinding()]
+			param (
+				$TestItem,
+				
+				[System.Collections.Hashtable]
+				$Parameters
+			)
+			
+			$setParam = $Parameters.Clone()
+			$properties = @{ }
+			$clear = @()
+			foreach ($change in $testItem.Changed) {
+				if (-not $change.NewValue -and 0 -ne $change.NewValue) { $clear += $change.Property }
+				else { $properties[$change.Property] = $change.NewValue }
+			}
+			if ($properties.Count -gt 0) { $setParam.Replace = $properties }
+			if ($clear) { $setParam.Clear = $clear }
+			
+			Set-ADServiceAccount @setParam -Identity $testItem.ADObject.ObjectGuid -Confirm:$false -ErrorAction Stop
+		}
+		#endregion Utility Functions
+		
+		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
+		$parameters['Debug'] = $false
+		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
+		Invoke-Callback @parameters -Cmdlet $PSCmdlet
+		Assert-Configuration -Type ServiceAccounts -Cmdlet $PSCmdlet
+		Set-DMDomainContext @parameters
+		
+		$categories = @{ }
+	}
+	process {
+		if (-not $InputObject) {
+			$InputObject = Test-DMServiceAccount @parameters
+		}
+		
+		:main foreach ($testItem in $InputObject) {
+			# Catch invalid input - can only process test results
+			if ($testItem.PSObject.TypeNames -notcontains 'DomainManagement.ServiceAccount.TestResult') {
+				Stop-PSFFunction -String 'General.Invalid.Input' -StringValues 'Test-DMServiceAccount', $testItem -Target $testItem -Continue -EnableException $EnableException
+			}
+			
+			switch ($testItem.Type) {
+				'Delete'
+				{
+					Invoke-PSFProtectedCommand -ActionString 'Invoke-DMServiceAccount.Deleting' -ActionStringValues $testItem.Identity -Target $testItem.Identity -ScriptBlock {
+						Remove-ADServiceAccount @parameters -Identity $testItem.ADObject.SamAccountName -ErrorAction Stop -Confirm:$false
+					} -EnableException $EnableException -PSCmdlet $PSCmdlet
+				}
+				'Create'
+				{
+					Invoke-PSFProtectedCommand -ActionString 'Invoke-DMServiceAccount.Creating' -ActionStringValues $testItem.Identity -Target $testItem.Identity -ScriptBlock {
+						New-ServiceAccount -TestItem $testItem -Parameters $parameters -Categories $categories
+					} -EnableException $EnableException -PSCmdlet $PSCmdlet
+				}
+				'Update'
+				{
+					Invoke-PSFProtectedCommand -ActionString 'Invoke-DMServiceAccount.Updating' -ActionStringValues $testItem.Identity -Target $testItem.Identity -ScriptBlock {
+						Set-ServiceAccount -TestItem $testItem -Parameters $parameters
+					} -EnableException $EnableException -PSCmdlet $PSCmdlet
+				}
+				'PrincipalUpdate'
+				{
+					Invoke-PSFProtectedCommand -ActionString 'Invoke-DMServiceAccount.UpdatingPrincipal' -ActionStringValues $testItem.Identity -Target $testItem.Identity -ScriptBlock {
+						$principals = ($testItem.Changed | Where-Object Type -EQ Update).NewValue
+						Set-ADServiceAccount @parameters -Identity $testItem.ADObject.ObjectGuid -PrincipalsAllowedToRetrieveManagedPassword $principals
+					} -EnableException $EnableException -PSCmdlet $PSCmdlet
+				}
+				'Move'
+				{
+					Invoke-PSFProtectedCommand -ActionString 'Invoke-DMServiceAccount.Moving' -ActionStringValues $testItem.Identity, $testItem.Changed.NewValue -Target $testItem.Identity -ScriptBlock {
+						Move-ADObject @parameters -Identity $testItem.ADObject.ObjectGuid -TargetPath $testItem.Changed.NewValue -Confirm:$false
+					} -EnableException $EnableException -PSCmdlet $PSCmdlet
+				}
+				'Rename'
+				{
+					Invoke-PSFProtectedCommand -ActionString 'Invoke-DMServiceAccount.Moving' -ActionStringValues $testItem.Identity -Target $testItem.Identity -ScriptBlock {
+						Rename-ADObject @parameters -Identity $testItem.ADObject.ObjectGuid -NewName $testItem.Changed.NewValue -Confirm:$false
+					} -EnableException $EnableException -PSCmdlet $PSCmdlet
+				}
+				'Enable'
+				{
+					Invoke-PSFProtectedCommand -ActionString 'Invoke-DMServiceAccount.Enabling' -ActionStringValues $testItem.Identity -Target $testItem.Identity -ScriptBlock {
+						Enable-ADAccount @parameters -Identity $testItem.ADObject.ObjectGuid -Confirm:$false
+					} -EnableException $EnableException -PSCmdlet $PSCmdlet
+				}
+				'Disable'
+				{
+					Invoke-PSFProtectedCommand -ActionString 'Invoke-DMServiceAccount.Disabling' -ActionStringValues $testItem.Identity -Target $testItem.Identity -ScriptBlock {
+						Disable-ADAccount @parameters -Identity $testItem.ADObject.ObjectGuid -Confirm:$false
+					} -EnableException $EnableException -PSCmdlet $PSCmdlet
+				}
+			}
+		}
+	}
+}

--- a/DomainManagement/functions/serviceaccounts/Register-DMServiceAccount.ps1
+++ b/DomainManagement/functions/serviceaccounts/Register-DMServiceAccount.ps1
@@ -1,0 +1,141 @@
+﻿function Register-DMServiceAccount {
+<#
+	.SYNOPSIS
+		Register a Group Managed Service Account as a desired state object.
+	
+	.DESCRIPTION
+		Register a Group Managed Service Account as a desired state object.
+		This will then be tested for during Test-DMServiceAccount and ensured during Invoke-DMServiceAccount.
+	
+	.PARAMETER Name
+		Name of the Service Account.
+		This must be a legal name, 15 characters or less (no trailing $ needed).
+		The SamAccountName will be automatically calculated based off this setting (by appending a $).
+		Supports string resolution.
+	
+	.PARAMETER DNSHostName
+		The DNSHostName of the gMSA.
+		Supports string resolution.
+	
+	.PARAMETER Description
+		Describe what the gMSA is supposed to be used for.
+		Supports string resolution.
+	
+	.PARAMETER Path
+		The path where to place the gMSA.
+		Supports string resolution.
+	
+	.PARAMETER ServicePrincipalName
+		Any service principal names to add to the gMSA.
+		Supports string resolution.
+	
+	.PARAMETER DisplayName
+		A custom DisplayName for the gMSA.
+		Note, this setting will be ignored in the default dsa.msc console!
+		It only affects other applications that might be gMSA aware and support it.
+		Supports string resolution.
+	
+	.PARAMETER ObjectCategory
+		Only thus designated principals are allowed to retrieve the password to the gMSA.
+		Using this you can grant access to any members of given Object Categories.
+	
+	.PARAMETER ComputerName
+		Only thus designated principals are allowed to retrieve the password to the gMSA.
+		Using this you can grant access to an explicit list of computer accounts.
+		A missing computer will cause a warning, but not otherwise fail the process.
+		Supports string resolution.
+	
+	.PARAMETER ComputerNameOptional
+		Only thus designated principals are allowed to retrieve the password to the gMSA.
+		Using this you can grant access to an explicit list of computer accounts.
+		A missing computer will be logged but not otherwise noted.
+		Supports string resolution.
+	
+	.PARAMETER Enabled
+		Whether the account should be enabled or disabled.
+		By default, this is 'Undefined', causing the workflow to ignore its enablement state.
+	
+	.PARAMETER Present
+		Whether the account should exist or not.
+		By default, it should.
+		Set this to $false in order to explicitly delete an existing gMSA.
+	
+	.PARAMETER Attributes
+		Offer additional attributes to define.
+		This can be either a hashtable or an object and can contain any writeable properties a gMSA can have in your organization.
+	
+	.EXAMPLE
+		PS C:\> Get-Content .\serviceaccounts.json | ConvertFrom-Json | Write-Output | Register-DMServiceAccount
+	
+		Load up all settings defined in serviceaccounts.json
+#>
+	[CmdletBinding()]
+	param (
+		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+		[string]
+		$Name,
+		
+		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+		[string]
+		$DNSHostName,
+		
+		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+		[string]
+		$Description,
+		
+		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+		[string]
+		$Path,
+		
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
+		[string[]]
+		$ServicePrincipalName = @(),
+		
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
+		[string]
+		$DisplayName,
+		
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
+		[string[]]
+		$ObjectCategory,
+		
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
+		[string[]]
+		$ComputerName,
+		
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
+		[string[]]
+		$ComputerNameOptional,
+		
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
+		[PSFramework.Utility.TypeTransformationAttribute([string])]
+		[DomainManagement.TriBool]
+		$Enabled = 'Undefined',
+		
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
+		[bool]
+		$Present = $true,
+		
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
+		$Attributes
+	)
+	
+	process {
+		$script:serviceAccounts[$Name] = [PSCustomObject]@{
+			PSTypeName		      = 'DomainManagement.Configuration.ServiceAccount'
+			Name				  = $Name
+			SamAccountName	      = $Name
+			DNSHostName		      = $DNSHostName
+			Description		      = $Description
+			Path				  = $Path
+			ServicePrincipalName  = $ServicePrincipalName
+			DisplayName		      = $DisplayName
+			ObjectCategory	      = $ObjectCategory
+			ComputerName		  = $ComputerName
+			ComputerNameOptional  = $ComputerNameOptional
+			Enabled			      = $Enabled
+			Present			      = $Present
+			Attributes		      = $Attributes | ConvertTo-PSFHashtable
+		}
+	}
+}

--- a/DomainManagement/functions/serviceaccounts/Register-DMServiceAccount.ps1
+++ b/DomainManagement/functions/serviceaccounts/Register-DMServiceAccount.ps1
@@ -63,6 +63,11 @@
 	.PARAMETER Attributes
 		Offer additional attributes to define.
 		This can be either a hashtable or an object and can contain any writeable properties a gMSA can have in your organization.
+
+	.PARAMETER ContextName
+		The name of the context defining the setting.
+		This allows determining the configuration set that provided this setting.
+		Used by the ADMF, available to any other configuration management solution.
 	
 	.EXAMPLE
 		PS C:\> Get-Content .\serviceaccounts.json | ConvertFrom-Json | Write-Output | Register-DMServiceAccount
@@ -117,7 +122,10 @@
 		$Present = $true,
 		
 		[Parameter(ValueFromPipelineByPropertyName = $true)]
-		$Attributes
+		$Attributes,
+		
+		[string]
+		$ContextName = '<Undefined>'
 	)
 	
 	process {
@@ -136,6 +144,7 @@
 			Enabled			      = $Enabled
 			Present			      = $Present
 			Attributes		      = $Attributes | ConvertTo-PSFHashtable
+			ContextName		     = $ContextName
 		}
 	}
 }

--- a/DomainManagement/functions/serviceaccounts/Test-DMServiceAccount.ps1
+++ b/DomainManagement/functions/serviceaccounts/Test-DMServiceAccount.ps1
@@ -1,0 +1,220 @@
+﻿function Test-DMServiceAccount {
+<#
+	.SYNOPSIS
+		Tests whether the currently deployed service accoaunts match the configured desired state.
+	
+	.DESCRIPTION
+		Tests whether the currently deployed service accoaunts match the configured desired state.
+		Use Register-DMServiceAccount to define the desired state.
+	
+	.PARAMETER Server
+		The server / domain to work with.
+		
+	.PARAMETER Credential
+		The credentials to use for this operation.
+	
+	.EXAMPLE
+		PS C:\> Test-DMServiceAccount -Server contoso.com
+	
+		Tests whether the service accounts in the contoso.com domain are compliant with the desired state.
+#>
+	[CmdletBinding()]
+	param (
+		[PSFComputer]
+		$Server,
+		
+		[PSCredential]
+		$Credential
+	)
+	
+	begin {
+		#region Utility Functions
+		function New-Change {
+			[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
+			[CmdletBinding()]
+			param (
+				$Identity,
+				
+				$Type,
+				
+				$Property,
+				
+				$Previous,
+				
+				$NewValue
+			)
+			
+			[pscustomobject]@{
+				PSTypeName = 'DomainManagement.Change.ServiceAccount'
+				Identity   = $Identity
+				Type	   = $Type
+				Property   = $Property
+				Previous   = $Previous
+				NewValue   = $NewValue
+			}
+		}
+		#endregion Utility Functions
+		
+		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
+		$parameters['Debug'] = $false
+		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
+		Invoke-Callback @parameters -Cmdlet $PSCmdlet
+		Assert-Configuration -Type serviceAccounts -Cmdlet $PSCmdlet
+		Set-DMDomainContext @parameters
+	}
+	process {
+		#region Prepare Object Categories
+		$rawCategories = $script:serviceAccounts.Values.ObjectCategory | Remove-PSFNull -Enumerate | Sort-Object -Unique
+		$categories = @{ }
+		foreach ($rawCategory in $rawCategories) {
+			$categories[$rawCategory] = Find-DMObjectCategoryItem -Name $rawCategory @parameters -Property SamAccountName
+		}
+		#endregion Prepare Object Categories
+		
+		#region Process Configured Objects
+		foreach ($serviceAccountDefinition in $script:serviceAccounts.Values) {
+			$resolvedName = (Resolve-String -Text $serviceAccountDefinition.SamAccountName @parameters) -replace '\$$'
+			$resolvedPath = Resolve-String -Text $serviceAccountDefinition.Path @parameters
+			$resolvedSAM = $resolvedName + '$'
+			
+			$resultDefaults = @{
+				Server	      = $Server
+				ObjectType    = 'ServiceAccount'
+				Identity	  = $resolvedName
+				Configuration = $serviceAccountDefinition
+			}
+			
+			try { $adObject = Get-ADServiceAccount @parameters -Identity $resolvedName -ErrorAction Stop -Properties * }
+			catch {
+				New-TestResult -Type Create @resultDefaults (New-Change -Identity $resolvedName -Type Create)
+				continue
+			}
+			$resultDefaults.ADObject = $adObject
+			
+			if (-not $serviceAccountDefinition.Present) {
+				New-TestResult -Type Delete @resultDefaults -Changed (New-Change -Identity $adObject.SamAccountName -Type Delete)
+				continue
+			}
+			
+			#region Compare Common Properties
+			$parentPath = $adObject.DistinguishedName -split ",", 2 | Select-Object -Last 1
+			if ($parentPath -ne $resolvedPath) {
+				New-TestResult -Type Move @resultDefaults -Changed (New-Change -Type Move -Property 'Path' -Previous $parentPath -NewValue $resolvedPath -Identity $resolvedName)
+			}
+			
+			if ($adObject.Name -ne $resolvedName) {
+				New-TestResult -Type Rename @resultDefaults -Changed (New-Change -Type Rename -Property 'Name' -Previous $adObject.Name -NewValue $resolvedName -Identity $resolvedName)
+			}
+			
+			[System.Collections.ArrayList]$changes = @()
+			Compare-Property -Property DNSHostName -Configuration $serviceAccountDefinition -ADObject $adObject -Changes $changes -Resolve -Parameters $parameters
+			Compare-Property -Property Description -Configuration $serviceAccountDefinition -ADObject $adObject -Changes $changes -Resolve -Parameters $parameters -AsString
+			Compare-Property -Property DisplayName -Configuration $serviceAccountDefinition -ADObject $adObject -Changes $changes -Resolve -Parameters $parameters -AsString
+			if ($adObject.ServicePrincipalName -or $serviceAccountDefinition.ServicePrincipalName) {
+				Compare-Property -Property ServicePrincipalName -Configuration $serviceAccountDefinition -ADObject $adObject -Changes $changes -Resolve -Parameters $parameters
+			}
+			if ($serviceAccountDefinition.Attributes.Count -gt 0) {
+				$attributesObject = [PSCustomObject]$serviceAccountDefinition.Attributes
+				foreach ($key in $serviceAccountDefinition.Attributes.Keys) {
+					Compare-Property -Property $key -Configuration $attributesObject -ADObject $adObject -Changes $changes
+				}
+			}
+			$defaultProperties = 'DNSHostName', 'Description', 'ServicePrincipalName', 'DisplayName'
+			$changeObjects = foreach ($change in $changes) {
+				if ($change -in $defaultProperties) { New-Change -Type Update -Property $change -Previous $adObject.$change -NewValue ($serviceAccountDefinition.$change | Resolve-String @parameters) -Identity $resolvedName }
+				else { New-Change -Type Update -Property $change -Previous $adObject.$change -NewValue $attributesObject.$change -Identity $resolvedName }
+			}
+			if ($changes) {
+				New-TestResult -Type Update @resultDefaults -Changed $changeObjects
+			}
+			#endregion Compare Common Properties
+			
+			#region Enabled
+			if ($serviceAccountDefinition.Enabled -ne 'Undefined') {
+				if ($adObject.Enabled -and -not $serviceAccountDefinition.Enabled) {
+					New-TestResult -Type Disable @resultDefaults -Changed (New-Change -Type Disable -Property Enabled -Previous $true -NewValue $false -Identity $resolvedName)
+				}
+				if (-not $adObject.Enabled -and $serviceAccountDefinition.Enabled) {
+					New-TestResult -Type Enable @resultDefaults -Changed (New-Change -Type Enable -Property Enabled -Previous $false -NewValue $true -Identity $resolvedName)
+				}
+			}
+			#endregion Enabled
+			
+			#region PrincipalsAllowedToRetrieveManagedPassword
+			# Use SamAccountName rather than DistinguishedName as accounts may not yet have been moved to their correct container so DN might fail
+			$currentPrincipals = ($adObject.PrincipalsAllowedToRetrieveManagedPassword | Get-ADObject @parameters -Properties SamAccountName).SamAccountName
+			
+			# Object Category
+			$desiredPrincipals = @()
+			foreach ($category in $serviceAccountDefinition.ObjectCategory) {
+				$categories[$category].SamAccountName | ForEach-Object {
+					$desiredPrincipals += $_
+				}
+			}
+			
+			# Direct Assignment
+			foreach ($name in $serviceAccountDefinition.ComputerName | Resolve-String @parameters) {
+				if ($name -notlike '*$') { $name = "$($name)$" }
+				try {
+					$null = Get-ADComputer -Identity $name -ErrorAction Stop
+					$desiredPrincipals += $name
+				}
+				catch {
+					Write-PSFMessage -Level Warning -String 'Test-DMServiceAccount.Computer.NotFound' -StringValues $name, $resolvedName -Target $serviceAccountDefinition -Tag error, failed, serviceaccount, computer
+					continue
+				}
+			}
+			
+			# Optional Direct Assignment
+			foreach ($name in $serviceAccountDefinition.ComputerNameOptional | Resolve-String @parameters) {
+				if ($name -notlike '*$') { $name = "$($name)$" }
+				try {
+					$null = Get-ADComputer -Identity $name -ErrorAction Stop
+					$desiredPrincipals += $name
+				}
+				catch {
+					Write-PSFMessage -Level Verbose -String 'Test-DMServiceAccount.Computer.Optional.NotFound' -StringValues $name, $resolvedName -Target $serviceAccountDefinition -Tag error, failed, serviceaccount, computer
+					continue
+				}
+			}
+			
+			$principalChanges = @()
+			foreach ($principal in $currentPrincipals) {
+				if ($principal -in $desiredPrincipals) { continue }
+				$principalChanges += New-Change -Type Remove -Property Principal -Previous $principal -Identity $resolvedName
+			}
+			foreach ($principal in $desiredPrincipals) {
+				if ($principal -in $currentPrincipals) { continue }
+				$principalChanges += New-Change -Type Add -Property Principal -NewValue $principal -Identity $resolvedName
+			}
+			if (-not $principalChanges) { continue }
+			
+			$principalChanges += New-Change -Type Update -Property Principal -Previous $currentPrincipals -NewValue $desiredPrincipals -Identity $resolvedName
+			New-TestResult -Type PrincipalUpdate @resultDefaults -Changed $principalChanges
+			#endregion PrincipalsAllowedToRetrieveManagedPassword
+		}
+		#endregion Process Configured Objects
+		
+		#region Process Non-Configuted AD-Objects
+		$foundServiceAccounts = foreach ($searchBase in (Resolve-ContentSearchBase @parameters)) {
+			Get-ADServiceAccount @parameters -LDAPFilter '(!(isCriticalSystemObject=TRUE))' -SearchBase $searchBase.SearchBase -SearchScope $searchBase.SearchScope
+		}
+		
+		$configuredNames = $script:serviceAccounts.Values.SamAccountName | Resolve-String @parameters | ForEach-Object {
+			if ($_ -like '*$') { $_ }
+			else { "$($_)$" }
+		}
+		
+		$resultDefaults = @{
+			Server	   = $Server
+			ObjectType = 'ServiceAccount'
+		}
+		
+		foreach ($foundServiceAccount in $foundServiceAccounts) {
+			if ($foundServiceAccount.SamAccountName -in $configuredNames) { continue }
+			
+			New-TestResult @resultDefaults -Type Delete -Identity $foundServiceAccount.SamAccountName -ADObject $foundServiceAccount -Changed (New-Change -Identity $foundServiceAccount.SamAccountName -Type Delete)
+		}
+		#endregion Process Non-Configuted AD-Objects
+	}
+}

--- a/DomainManagement/functions/serviceaccounts/Unregister-DMServiceAccount.ps1
+++ b/DomainManagement/functions/serviceaccounts/Unregister-DMServiceAccount.ps1
@@ -1,0 +1,32 @@
+﻿function Unregister-DMServiceAccount
+{
+<#
+	.SYNOPSIS
+		Removes a service account from the list of registered service accounts.
+	
+	.DESCRIPTION
+		Removes a service account from the list of registered service accounts.
+	
+	.PARAMETER Name
+		The account to remove.
+	
+	.EXAMPLE
+		PS C:\> Get-DMServiceAccount | Unregister-DMServiceAccount
+	
+		Clear all configured service accounts.
+#>
+	[CmdletBinding()]
+	param (
+		[Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+		[string[]]
+		$Name
+	)
+	
+	process
+	{
+		foreach ($nameItem in $Name)
+		{
+			$script:serviceAccounts.Remove($nameItem)
+		}
+	}
+}

--- a/DomainManagement/functions/users/Invoke-DMUser.ps1
+++ b/DomainManagement/functions/users/Invoke-DMUser.ps1
@@ -66,12 +66,12 @@
 			}
 			
 			switch ($testItem.Type) {
-				'ShouldDelete' {
+				'Delete' {
 					Invoke-PSFProtectedCommand -ActionString 'Invoke-DMUser.User.Delete' -Target $testItem -ScriptBlock {
 						Remove-ADUser @parameters -Identity $testItem.ADObject.ObjectGUID -ErrorAction Stop -Confirm:$false
 					} -EnableException $EnableException.ToBool() -PSCmdlet $PSCmdlet -Continue
 				}
-				'ConfigurationOnly' {
+				'Create' {
 					$targetOU = Resolve-String -Text $testItem.Configuration.Path
 					try { $null = Get-ADObject @parameters -Identity $targetOU -ErrorAction Stop }
 					catch { Stop-PSFFunction -String 'Invoke-DMUser.User.Create.OUExistsNot' -StringValues $targetOU, $testItem.Identity -Target $testItem -EnableException $EnableException -Continue -ContinueLabel main }

--- a/DomainManagement/functions/users/Register-DMUser.ps1
+++ b/DomainManagement/functions/users/Register-DMUser.ps1
@@ -49,6 +49,10 @@
 	.PARAMETER Enabled
 		Whether the user object should be enabled or disabled.
 		Defaults to: Undefined
+
+	.PARAMETER Optional
+		By default, all defined user accounts must exist.
+		By setting a user account optional, it will be tolerated if it exists, but not created if it does not.
 	
 	.PARAMETER OldNames
 		Previous names the user object had.
@@ -102,6 +106,10 @@
 		[PSFramework.Utility.TypeTransformationAttribute([string])]
 		[DomainManagement.TriBool]
 		$Enabled = 'Undefined',
+
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
+		[bool]
+		$Optional,
 		
 		[Parameter(ValueFromPipelineByPropertyName = $true)]
 		[string[]]
@@ -115,18 +123,19 @@
 	process {
 		
 		$userHash = @{
-			PSTypeName		     = 'DomainManagement.User'
-			SamAccountName	     = $SamAccountName
-			Name				 = $Name
-			GivenName		     = $GivenName
-			Surname			     = $Surname
-			Description		     = $null
+			PSTypeName           = 'DomainManagement.User'
+			SamAccountName       = $SamAccountName
+			Name                 = $Name
+			GivenName            = $GivenName
+			Surname              = $Surname
+			Description          = $null
 			PasswordNeverExpires = $PasswordNeverExpires.ToBool()
 			UserPrincipalName    = $UserPrincipalName
-			Path				 = $Path
-			Enabled			     = $Enabled
-			OldNames			 = $OldNames
-			Present			     = $Present
+			Path                 = $Path
+			Enabled              = $Enabled
+			Optional             = $Optional
+			OldNames             = $OldNames
+			Present              = $Present
 		}
 		if ($Description) {
 			$userHash['Description'] = $Description

--- a/DomainManagement/functions/users/Test-DMUser.ps1
+++ b/DomainManagement/functions/users/Test-DMUser.ps1
@@ -55,7 +55,7 @@
 				try { $adObject = Get-ADUser @parameters -Identity $resolvedSamAccName -Properties Description, PasswordNeverExpires -ErrorAction Stop }
 				catch { continue } # Only errors when user not present = All is well
 				
-				New-TestResult @resultDefaults -Type ShouldDelete -ADObject $adObject
+				New-TestResult @resultDefaults -Type Delete -ADObject $adObject
 				continue
 			}
 			#endregion User that needs to be removed
@@ -73,7 +73,9 @@
 					#region Case: No old version present
 					0
 					{
-						New-TestResult @resultDefaults -Type ConfigurationOnly
+						if (-not $userDefinition.Optional) {
+							New-TestResult @resultDefaults -Type Create
+						}
 						continue main
 					}
 					#endregion Case: No old version present
@@ -141,7 +143,7 @@
 			if (1000 -ge ($existingUser.SID -split "-")[-1]) { continue } # Ignore BuiltIn default users
 			if ($exclusionPattern -and $existingUser.Name -match $exclusionPattern) { continue } # Skip whitelisted usernames
 
-			New-TestResult @resultDefaults -Type ShouldDelete -ADObject $existingUser -Identity $existingUser.Name
+			New-TestResult @resultDefaults -Type Delete -ADObject $existingUser -Identity $existingUser.Name
 		}
 		#endregion Process Managed Containers
 	}

--- a/DomainManagement/internal/scripts/variables.ps1
+++ b/DomainManagement/internal/scripts/variables.ps1
@@ -68,6 +68,9 @@ $script:domainLevel = $null
 # Configured Exchange Domain Setting Versions
 $script:exchangeVersion = $null
 
+# Configured Group Managed Service Accounts
+$script:serviceAccounts = @{ }
+
 
 #----------------------------------------------------------------------------#
  #                                Cached Data                                 #

--- a/DomainManagement/tests/general/Help.Tests.ps1
+++ b/DomainManagement/tests/general/Help.Tests.ps1
@@ -48,7 +48,7 @@ if ($SkipTest) { return }
 . $ExceptionsFile
 
 $includedNames = (Get-ChildItem $CommandPath -Recurse -File | Where-Object Name -like "*.ps1").BaseName
-$commands = Get-Command -Module (Get-Module $ModuleName) -CommandType Cmdlet, Function, Workflow | Where-Object Name -in $includedNames
+$commands = Get-Command -Module (Get-Module $ModuleName) -CommandType Cmdlet, Function | Where-Object Name -in $includedNames
 
 ## When testing help, remember that help is cached at the beginning of each session.
 ## To test, restart session.

--- a/DomainManagement/xml/DomainManagement.Format.ps1xml
+++ b/DomainManagement/xml/DomainManagement.Format.ps1xml
@@ -15,6 +15,7 @@
                 <TypeName>DomainManagement.Object.TestResult</TypeName>
                 <TypeName>DomainManagement.OrganizationalUnit.TestResult</TypeName>
                 <TypeName>DomainManagement.PSO.TestResult</TypeName>
+				<TypeName>DomainManagement.ServiceAccount.TestResult</TypeName>
                 <TypeName>DomainManagement.User.TestResult</TypeName>
             </Types>
         </SelectionSet>
@@ -135,6 +136,45 @@ else { $_.Category }
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>Optional</PropertyName>
+                            </TableColumnItem>
+                        </TableColumnItems>
+                    </TableRowEntry>
+                </TableRowEntries>
+            </TableControl>
+        </View>
+		
+		<!-- DomainManagement.Change.ServiceAccount -->
+        <View>
+            <Name>DomainManagement.Change.ServiceAccount</Name>
+            <ViewSelectedBy>
+                <TypeName>DomainManagement.Change.ServiceAccount</TypeName>
+            </ViewSelectedBy>
+            <TableControl>
+                <AutoSize/>
+                <TableHeaders>
+                    <TableColumnHeader/>
+                    <TableColumnHeader/>
+                    <TableColumnHeader/>
+                    <TableColumnHeader/>
+                    <TableColumnHeader/>
+                </TableHeaders>
+                <TableRowEntries>
+                    <TableRowEntry>
+                        <TableColumnItems>
+                            <TableColumnItem>
+                                <PropertyName>Identity</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Type</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Property</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Previous</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>NewValue</PropertyName>
                             </TableColumnItem>
                         </TableColumnItems>
                     </TableRowEntry>


### PR DESCRIPTION
- New: Component: Service Accounts - manage Group Managed Service Accounts
- New: Command Find-DMObjectCategoryItem - Searches objects that are part of a specified object category.
- Upd: Register-DMObjectCategory - Added SearchBase and SearchScope parameters.
- Upd: Resolve-DMObjectCategory - Added support for Searchbase and Searchscope of object categories.
- Upd: GroupMembership - allowed computer objects
- Upd: Organizational Units - added option for "optional", tolerating an existing OU but not creating it
- Upd: Organizational Units - renamed change type "ConfigurationOnly" to "Create"
- Upd: Organizational Units - renamed change type "ShouldDelete" to "Delete"
- Upd: Users - added option for "optional", tolerating an existing OU but not creating it
- Upd: Users - renamed change type "ConfigurationOnly" to "Create"
- Upd: Users - renamed change type "ShouldDelete" to "Delete"
- Fix: Test-DMGroupMembership - incorrectly reports foreign security principals that were resolved as "unidentified" if another fsp was incorrectly a group member.