### PR TITLE
1.6.131

### DIFF
--- a/DomainManagement/DomainManagement.psd1
+++ b/DomainManagement/DomainManagement.psd1
@@ -3,7 +3,7 @@
 	RootModule         = 'DomainManagement.psm1'
 	
 	# Version number of this module.
-	ModuleVersion      = '1.6.129'
+	ModuleVersion      = '1.6.131'
 	
 	# ID used to uniquely identify this module
 	GUID               = '0a405382-ebc2-445b-8325-541535810193'

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -1,5 +1,10 @@
 ﻿# Changelog
 
+## 1.6.131 (2021-07-13)
+
+- Upd: AccessRules - added "Present" configuration, allowing explicit delete actions as well as optional rule pressence
+- Fix: Test-DMAccessRule - fixed unintended command interruption when Identity on AD object could not be unresolved
+
 ## 1.6.129 (2021-05-28)
 
 - Upd: Group Memberships - can now assign Object Categories

--- a/DomainManagement/functions/AccessRule/Register-DMAccessRule.ps1
+++ b/DomainManagement/functions/AccessRule/Register-DMAccessRule.ps1
@@ -1,6 +1,5 @@
-﻿function Register-DMAccessRule
-{
-	<#
+﻿function Register-DMAccessRule {
+    <#
 	.SYNOPSIS
 		Registers a new access rule as a desired state.
 	
@@ -52,83 +51,94 @@
 		This makes the rule apply only if the object exists, without triggering errors if it doesn't.
 		It will also ignore access errors on the object.
 		Note: Only if all access rules assigned to an object are set to $true, will the object be considered optional.
+
+    .PARAMETER Present
+		Whether the access rule should exist or not.
+		By default, it should.
+		Set this to $false in order to explicitly delete an existing access rule.
+        Set this to 'Undefined' to neither create nor delete it, in which case it will simply be accepted if it exists.
 	
 	.EXAMPLE
 		PS C:\> Register-DMAccessRule -ObjectCategory DomainControllers -Identity '%DomainName%\Domain Admins' -ActiveDirectoryRights GenericAll
 
 		Grants the domain admins of the target domain FullControl over all domain controllers, without any inheritance.
 	#>
-	[CmdletBinding(DefaultParameterSetName = 'Path')]
-	Param (
-		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Path')]
-		[string]
-		$Path,
+    [CmdletBinding(DefaultParameterSetName = 'Path')]
+    Param (
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Path')]
+        [string]
+        $Path,
 
-		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Category')]
-		[string]
-		$ObjectCategory,
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Category')]
+        [string]
+        $ObjectCategory,
 
-		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
-		[string]
-		$Identity,
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [string]
+        $Identity,
 
-		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
-		[string]
-		$ActiveDirectoryRights,
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [string]
+        $ActiveDirectoryRights,
 
-		[Parameter(ValueFromPipelineByPropertyName = $true)]
-		[System.Security.AccessControl.AccessControlType]
-		$AccessControlType = 'Allow',
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [System.Security.AccessControl.AccessControlType]
+        $AccessControlType = 'Allow',
 
-		[Parameter(ValueFromPipelineByPropertyName = $true)]
-		[System.DirectoryServices.ActiveDirectorySecurityInheritance]
-		$InheritanceType = 'None',
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [System.DirectoryServices.ActiveDirectorySecurityInheritance]
+        $InheritanceType = 'None',
 
-		[Parameter(ValueFromPipelineByPropertyName = $true)]
-		[string]
-		$ObjectType = '<All>',
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [string]
+        $ObjectType = '<All>',
 
-		[Parameter(ValueFromPipelineByPropertyName = $true)]
-		[string]
-		$InheritedObjectType = '<All>',
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [string]
+        $InheritedObjectType = '<All>',
 
-		[Parameter(ValueFromPipelineByPropertyName = $true)]
-		[bool]
-		$Optional = $false
-	)
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [bool]
+        $Optional = $false,
+		
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [PSFramework.Utility.TypeTransformationAttribute([string])]
+        [DomainManagement.TriBool]
+        $Present = 'true'
+    )
 	
-	process
-	{
-		switch ($PSCmdlet.ParameterSetName)
-		{
-			'Path' {
-				if (-not $script:accessRules[$Path]) { $script:accessRules[$Path] = @() }
-				$script:accessRules[$Path] += [PSCustomObject]@{
-					PSTypeName = 'DomainManagement.AccessRule'
-					Path = $Path
-					IdentityReference = $Identity
-					AccessControlType = $AccessControlType
-					ActiveDirectoryRights = $ActiveDirectoryRights
-					InheritanceType = $InheritanceType
-					InheritedObjectType = $InheritedObjectType
-					ObjectType = $ObjectType
-					Optional = $Optional
-				}
-			}
-			'Category' {
-				if (-not $script:accessCategoryRules[$ObjectCategory]) { $script:accessCategoryRules[$ObjectCategory] = @() }
-				$script:accessCategoryRules[$ObjectCategory] += [PSCustomObject]@{
-					PSTypeName = 'DomainManagement.AccessRule'
-					Category = $ObjectCategory
-					IdentityReference = $Identity
-					AccessControlType = $AccessControlType
-					ActiveDirectoryRights = $ActiveDirectoryRights
-					InheritanceType = $InheritanceType
-					InheritedObjectType = $InheritedObjectType
-					ObjectType = $ObjectType
-					Optional = $Optional
-				}
-			}
-		}
-	}
+    process {
+        switch ($PSCmdlet.ParameterSetName) {
+            'Path' {
+                if (-not $script:accessRules[$Path]) { $script:accessRules[$Path] = @() }
+                $script:accessRules[$Path] += [PSCustomObject]@{
+                    PSTypeName            = 'DomainManagement.AccessRule'
+                    Path                  = $Path
+                    IdentityReference     = $Identity
+                    AccessControlType     = $AccessControlType
+                    ActiveDirectoryRights = $ActiveDirectoryRights
+                    InheritanceType       = $InheritanceType
+                    InheritedObjectType   = $InheritedObjectType
+                    ObjectType            = $ObjectType
+                    Optional              = $Optional
+                    Present               = $Present
+                }
+            }
+            'Category' {
+                if (-not $script:accessCategoryRules[$ObjectCategory]) { $script:accessCategoryRules[$ObjectCategory] = @() }
+                $script:accessCategoryRules[$ObjectCategory] += [PSCustomObject]@{
+                    PSTypeName            = 'DomainManagement.AccessRule'
+                    Category              = $ObjectCategory
+                    IdentityReference     = $Identity
+                    AccessControlType     = $AccessControlType
+                    ActiveDirectoryRights = $ActiveDirectoryRights
+                    InheritanceType       = $InheritanceType
+                    InheritedObjectType   = $InheritedObjectType
+                    ObjectType            = $ObjectType
+                    Optional              = $Optional
+                    Present               = $Present
+                }
+            }
+        }
+    }
 }

--- a/DomainManagement/functions/AccessRule/Test-DMAccessRule.ps1
+++ b/DomainManagement/functions/AccessRule/Test-DMAccessRule.ps1
@@ -114,18 +114,25 @@
 			}
 
 			:outer foreach ($relevantADRule in $relevantADRules) {
-				# Don't generate delete changes
+				foreach ($configuredRule in $ConfiguredRules) {
+					if (Test-AccessRuleEquality -Parameters $parameters -Rule1 $relevantADRule -Rule2 $configuredRule) {
+                        # If explicitly defined for deletion, do so
+                        if ('False' -eq $configuredRule.Present) {
+                            Write-Result -Type Delete -Identity $relevantADRule.IdentityReference -ADObject $relevantADRule -DistinguishedName $ADObject
+                        }
+                        continue outer
+                    }
+				}
+
+                # Don't generate delete changes
 				if ($processingMode -eq 'Additive') { break }
-				# Don't generate delete changes, unless we have configured a permission level for the affected identity
+                # Don't generate delete changes, unless we have configured a permission level for the affected identity
 				if ($processingMode -eq 'Defined') {
 					if (-not ($relevantADRule.IdentityReference | Compare-Identity -Parameters $parameters -ReferenceIdentity $ConfiguredRules.IdentityReference -IncludeEqual -ExcludeDifferent)) {
 						continue
 					}
 				}
 
-				foreach ($configuredRule in $ConfiguredRules) {
-					if (Test-AccessRuleEquality -Parameters $parameters -Rule1 $relevantADRule -Rule2 $configuredRule) { continue outer }
-				}
 				Write-Result -Type Delete -Identity $relevantADRule.IdentityReference -ADObject $relevantADRule -DistinguishedName $ADObject
 			}
 
@@ -139,6 +146,8 @@
 				foreach ($relevantADRule in $relevantADRules) {
 					if (Test-AccessRuleEquality -Parameters $parameters -Rule1 $relevantADRule -Rule2 $configuredRule) { continue outer }
 				}
+                # Do not generate Create rules for any rule not configured for creation
+                if ('True' -ne $configuredRule.Present) { continue }
 				Write-Result -Type Create -Identity $configuredRule.IdentityReference -Configuration $configuredRule -DistinguishedName $ADObject
 			}
 		}
@@ -173,7 +182,10 @@
 					$inheritedObjectTypeName = $convertCmdName.Process($ruleObject.InheritedObjectType)[0]
 
 					try { $identity = Resolve-Identity @parameters -IdentityReference $ruleObject.IdentityReference -ADObject $ADObject }
-					catch { Stop-PSFFunction -String 'Convert-AccessRule.Identity.ResolutionError' -Target $ruleObject -ErrorRecord $_ -Continue }
+					catch {
+                        if ('True' -ne $ruleObject.Present) { continue }
+                        Stop-PSFFunction -String 'Convert-AccessRule.Identity.ResolutionError' -Target $ruleObject -ErrorRecord $_ -Continue
+                    }
 
 					[PSCustomObject]@{
 						PSTypeName = 'DomainManagement.AccessRule.Converted'
@@ -188,6 +200,7 @@
 						ObjectType = $objectTypeGuid
 						ObjectTypeName = $objectTypeName
 						PropagationFlags = $ruleObject.PropagationFlags
+                        Present = $ruleObject.Present
 					}
 				}
 			}
@@ -226,10 +239,16 @@
 					}
 					
 					if (-not $accessRule.IdentityReference.AccountDomainSid) {
-						$identity = Get-Principal @parameters -Sid $accessRule.IdentityReference -Domain $domainObject.DNSRoot -OutputType NTAccount
+                        try {$identity = Get-Principal @parameters -Sid $accessRule.IdentityReference -Domain $domainObject.DNSRoot -OutputType NTAccount}
+						catch { 
+                            # Empty Catch is OK here, warning happens in command
+                        }
 					}
 					else {
-						$identity = Get-Principal @parameters -Sid $accessRule.IdentityReference -Domain $accessRule.IdentityReference -OutputType NTAccount
+						try { $identity = Get-Principal @parameters -Sid $accessRule.IdentityReference -Domain $accessRule.IdentityReference -OutputType NTAccount }
+                        catch { 
+                            # Empty Catch is OK here, warning happens in command
+                        }
 					}
 					if (-not $identity) {
 						$identity = $accessRule.IdentityReference
@@ -328,6 +347,7 @@
 						ObjectType = $objectTypeGuid
 						ObjectTypeName = $objectTypeName
 						PropagationFlags = $ruleObject.PropagationFlags
+                        Present = $ruleObject.Present
 					}
 				}
 			}

--- a/DomainManagement/functions/AccessRule/Test-DMAccessRule.ps1
+++ b/DomainManagement/functions/AccessRule/Test-DMAccessRule.ps1
@@ -215,6 +215,7 @@
 		}
 
 		function Convert-AccessRuleIdentity {
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingEmptyCatchBlock', '')]
 			[CmdletBinding()]
 			param (
 				[Parameter(ValueFromPipeline = $true)]
@@ -239,14 +240,14 @@
 					}
 					
 					if (-not $accessRule.IdentityReference.AccountDomainSid) {
-                        try {$identity = Get-Principal @parameters -Sid $accessRule.IdentityReference -Domain $domainObject.DNSRoot -OutputType NTAccount}
-						catch { 
+                        try { $identity = Get-Principal @parameters -Sid $accessRule.IdentityReference -Domain $domainObject.DNSRoot -OutputType NTAccount }
+						catch {
                             # Empty Catch is OK here, warning happens in command
                         }
 					}
 					else {
 						try { $identity = Get-Principal @parameters -Sid $accessRule.IdentityReference -Domain $accessRule.IdentityReference -OutputType NTAccount }
-                        catch { 
+                        catch {
                             # Empty Catch is OK here, warning happens in command
                         }
 					}


### PR DESCRIPTION
- Upd: AccessRules - added "Present" configuration, allowing explicit delete actions as well as optional rule pressence
- Fix: Test-DMAccessRule - fixed unintended command interruption when Identity on AD object could not be unresolved