### PR TITLE
1.7.150

### DIFF
--- a/DomainManagement/DomainManagement.psd1
+++ b/DomainManagement/DomainManagement.psd1
@@ -3,7 +3,7 @@
 	RootModule         = 'DomainManagement.psm1'
 	
 	# Version number of this module.
-	ModuleVersion      = '1.7.145'
+	ModuleVersion      = '1.7.150'
 	
 	# ID used to uniquely identify this module
 	GUID               = '0a405382-ebc2-445b-8325-541535810193'

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -1,5 +1,11 @@
 ﻿# Changelog
 
+## ???
+
+- Upd: GroupPolicy - New state for group policies that are out of date and have been modified outside of the system
+- Upd: Organizational Units - TestResults with the DELETE action now show the full DN as identity
+- Fix: AService Accounts - Modifying the "KerberosEncryptionType" property of existing accounts fails
+
 ## 1.7.145 (2022-03-18)
 
 - New: Component "Group Policy Ownership"

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -4,7 +4,9 @@
 
 - Upd: GroupPolicy - New state for group policies that are out of date and have been modified outside of the system
 - Upd: Organizational Units - TestResults with the DELETE action now show the full DN as identity
-- Fix: AService Accounts - Modifying the "KerberosEncryptionType" property of existing accounts fails
+- Upd: Domain Level - Adding support to accept test results via pipeline for consistency reasons
+- Fix: Service Accounts - Modifying the "KerberosEncryptionType" property of existing accounts fails
+- Fix: Group Members - Identity fails to include member when trying to remove foreign security principals
 
 ## 1.7.145 (2022-03-18)
 

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -1,8 +1,8 @@
 ﻿# Changelog
 
-## ???
+## 1.7.150 (2022-09-16)
 
-- Upd: GroupPolicy - New state for group policies that are out of date and have been modified outside of the system
+- Upd: GroupPolicy - New state for group policies that are both out of date and have been modified outside of the system
 - Upd: Organizational Units - TestResults with the DELETE action now show the full DN as identity
 - Upd: Domain Level - Adding support to accept test results via pipeline for consistency reasons
 - Fix: Service Accounts - Modifying the "KerberosEncryptionType" property of existing accounts fails

--- a/DomainManagement/en-us/strings.psd1
+++ b/DomainManagement/en-us/strings.psd1
@@ -112,6 +112,7 @@
 	'Invoke-DMGroupPolicy.Install.OnConfigError'                        = 'Re-applying GPO "{0}" after failing to read its configuration' # $testItem.Identity
 	'Invoke-DMGroupPolicy.Install.OnManage'                             = 'Re-Applying GPO "{0}" for the first time to bring it under management' # $testItem.Identity
 	'Invoke-DMGroupPolicy.Install.OnModify'                             = 'GPO "{0}" was modified outside this system, re-applying GPO' # $testItem.Identity
+	'Invoke-DMGroupPolicy.Install.OnModifiedAndUpdate'                  = 'GPO "{0}" was modified outside this system and is based off an older version of the defined settings, re-applying GPO' # $testItem.Identity
 	'Invoke-DMGroupPolicy.Install.OnNew'                                = 'GPO "{0}" not found in AD, creating new GPO' # $testItem.Identity
 	'Invoke-DMGroupPolicy.Install.OnUpdate'                             = 'New GPO definition available, updating GPO "{0}"' # $testItem.Identity
 	'Invoke-DMGroupPolicy.Remote.WorkingDirectory.Failed'               = 'Failed to create working directory on {0}. This is required for importing GPOs' # $computerName

--- a/DomainManagement/functions/AccessRule/Test-DMAccessRule.ps1
+++ b/DomainManagement/functions/AccessRule/Test-DMAccessRule.ps1
@@ -453,7 +453,12 @@
 		$convertCmdGuid = { Convert-DMSchemaGuid @parameters -OutType Guid }.GetSteppablePipeline()
 		$convertCmdGuid.Begin($true)
 
+		$processed = @{ }
 		foreach ($foundADObject in $foundADObjects) {
+			# Prevent duplicate processing
+			if ($processed[$foundADObject.DistinguishedName]) { continue }
+			$processed[$foundADObject.DistinguishedName] = $true
+
 			# Skip items that were defined in configuration, they were already processed
 			if ($foundADObject.DistinguishedName -in $resolvedConfiguredObjects) { continue }
 

--- a/DomainManagement/functions/acls/Test-DMAcl.ps1
+++ b/DomainManagement/functions/acls/Test-DMAcl.ps1
@@ -126,8 +126,15 @@
 			ObjectType = 'Acl'
 		}
 
+		$processed = @{ }
 		foreach ($foundADObject in $foundADObjects) {
+			# Prevent duplicate processing
+			if ($processed[$foundADObject.DistinguishedName]) { continue }
+			$processed[$foundADObject.DistinguishedName] = $true
+
+			# Skip items that were defined in configuration, they were already processed
 			if ($foundADObject.DistinguishedName -in $resolvedConfiguredPaths) { continue }
+			
 			if ($script:aclByCategory.Count -gt 0) {
 				$category = Resolve-DMObjectCategory -ADObject $foundADObject @parameters
 				if ($matchingCategory = $category | Where-Object Name -in $script:aclByCategory.Keys | Select-Object -First 1) {

--- a/DomainManagement/functions/groupmemberships/Test-DMGroupMembership.ps1
+++ b/DomainManagement/functions/groupmemberships/Test-DMGroupMembership.ps1
@@ -167,12 +167,18 @@
                     ADObject   = $adMember
                 }
 
+				$identifier = $adMember.SamAccountName
+				if (-not $identifier) {
+					try { $identifier = Resolve-Principal -Name $adMember.ObjectSid -OutputType SamAccountName -ErrorAction Stop }
+					catch { $identifier = $adMember.ObjectSid }
+				}
+				if (-not $identifier) { $identifier = $adMember.ObjectSid }
                 if ($failedResolveAssignment -and ($adMember.ObjectClass -eq 'foreignSecurityPrincipal')) {
                     # Currently a member, is foreignSecurityPrincipal and we cannot be sure we resolved everything that should be member
-                    New-TestResult @resultDefaults -Type Unidentified -Identity "$($adObject.Name)þ$($adMember.ObjectClass)þ$($adMember.SamAccountName)" -Configuration $configObject -ADObject $adObject
+                    New-TestResult @resultDefaults -Type Unidentified -Identity "$($adObject.Name)þ$($adMember.ObjectClass)þ$($identifier)" -Configuration $configObject -ADObject $adObject
                 }
                 else {
-                    New-TestResult @resultDefaults -Type Remove -Identity "$($adObject.Name)þ$($adMember.ObjectClass)þ$($adMember.SamAccountName)" -Configuration $configObject -ADObject $adObject
+                    New-TestResult @resultDefaults -Type Remove -Identity "$($adObject.Name)þ$($adMember.ObjectClass)þ$($identifier)" -Configuration $configObject -ADObject $adObject
                 }
             }
             #endregion Compare existing state to assignments

--- a/DomainManagement/functions/groupmemberships/Test-DMGroupMembership.ps1
+++ b/DomainManagement/functions/groupmemberships/Test-DMGroupMembership.ps1
@@ -77,7 +77,7 @@
                         $failedResolveAssignment = $true
                         [PSCustomObject]@{
                             Assignment = $assignment
-                            ADObject   = $null
+                            ADMember   = $null
                             Type       = 'Explicit'
                         }
                         continue
@@ -89,14 +89,14 @@
                         $failedResolveAssignment = $true
                         [PSCustomObject]@{
                             Assignment = $assignment
-                            ADObject   = $null
+                            ADMember   = $null
                             Type       = 'Explicit'
                         }
                         continue
                     }
                     [PSCustomObject]@{
                         Assignment = $assignment
-                        ADObject   = $adResult
+                        ADMember   = $adResult
                         Type       = 'Explicit'
                     }
                 }
@@ -112,7 +112,7 @@
                     foreach ($adObject in $adObjects) {
                         [PSCustomObject]@{
                             Assignment = $assignment
-                            ADObject   = $adObject
+                            ADMember   = $adObject
                             Type       = 'Category'
                         }
                     }
@@ -139,7 +139,7 @@
 
             #region Compare Assignments to existing state
             foreach ($assignment in $assignments) {
-                if (-not $assignment.ADObject) {
+                if (-not $assignment.ADMember) {
                     # Principal that should be member could not be found
                     New-TestResult @resultDefaults -Type Unresolved -Identity "$(Resolve-String -Text $assignment.Assignment.Group)þ$($assignment.Assignment.ItemType)þ$(Resolve-String -Text $assignment.Assignment.Name)" -Configuration $assignment -ADObject $adObject
                     continue
@@ -164,7 +164,7 @@
                 }
                 $configObject = [PSCustomObject]@{
                     Assignment = $null
-                    ADObject   = $adMember
+                    ADMember   = $adMember
                 }
 
 				$identifier = $adMember.SamAccountName

--- a/DomainManagement/functions/grouppolicies/Invoke-DMGroupPolicy.ps1
+++ b/DomainManagement/functions/grouppolicies/Invoke-DMGroupPolicy.ps1
@@ -116,6 +116,11 @@
 				'CriticalError' {
 					Write-PSFMessage -Level Warning -String 'Invoke-DMGroupPolicy.Skipping.InCriticalState' -StringValues $testItem.Identity -Target $testItem
 				}
+				'ModifiedAndUpdate' {
+					Invoke-PSFProtectedCommand -ActionString 'Invoke-DMGroupPolicy.Install.OnModifiedAndUpdate' -ActionStringValues $testItem.Identity -Target $testItem -ScriptBlock {
+						Install-GroupPolicy -Session $session -Configuration $testItem.Configuration -WorkingDirectory $gpoRemotePath -ErrorAction Stop
+					} -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
+				}
 				'Update' {
 					Invoke-PSFProtectedCommand -ActionString 'Invoke-DMGroupPolicy.Install.OnUpdate' -ActionStringValues $testItem.Identity -Target $testItem -ScriptBlock {
 						Install-GroupPolicy -Session $session -Configuration $testItem.Configuration -WorkingDirectory $gpoRemotePath -ErrorAction Stop

--- a/DomainManagement/functions/grouppolicies/Test-DMGroupPolicy.ps1
+++ b/DomainManagement/functions/grouppolicies/Test-DMGroupPolicy.ps1
@@ -104,12 +104,16 @@
 				'CriticalError' { New-TestResult @resultDefaults -Type 'CriticalError' -Identity $desiredPolicy.DisplayName -Configuration $desiredPolicy -ADObject $managedHash[$desiredPolicy.DisplayName] }
 				'Healthy' {
 					$policyObject = $managedHash[$desiredPolicy.DisplayName]
-					if ($desiredPolicy.ExportID -ne $policyObject.ExportID) {
-						New-TestResult @resultDefaults -Type 'Update' -Identity $desiredPolicy.DisplayName -Configuration $desiredPolicy -ADObject $policyObject
+					if (($policyObject.Version -ne $policyObject.ADVersion) -and ($desiredPolicy.ExportID -ne $policyObject.ExportID)) {
+						New-TestResult @resultDefaults -Type 'ModifiedAndUpdate' -Identity $desiredPolicy.DisplayName -Configuration $desiredPolicy -ADObject $policyObject
 						continue
 					}
 					if ($policyObject.Version -ne $policyObject.ADVersion) {
 						New-TestResult @resultDefaults -Type 'Modified' -Identity $desiredPolicy.DisplayName -Configuration $desiredPolicy -ADObject $policyObject
+						continue
+					}
+					if ($desiredPolicy.ExportID -ne $policyObject.ExportID) {
+						New-TestResult @resultDefaults -Type 'Update' -Identity $desiredPolicy.DisplayName -Configuration $desiredPolicy -ADObject $policyObject
 						continue
 					}
 					$registryTest = Test-DMGPRegistrySetting -Server $session -PolicyName $desiredPolicy.DisplayName -PassThru

--- a/DomainManagement/functions/organizationalunits/Test-DMOrganizationalUnit.ps1
+++ b/DomainManagement/functions/organizationalunits/Test-DMOrganizationalUnit.ps1
@@ -120,7 +120,7 @@
 		foreach ($existingOU in $foundOUs) {
 			if ($existingOU.DistinguishedName -in $resolvedConfiguredNames) { continue } # Ignore configured OUs - they were previously configured for moving them, if they should not be in these containers
 			
-			New-TestResult @resultDefaults -Type Delete -ADObject $existingOU -Identity $existingOU.Name
+			New-TestResult @resultDefaults -Type Delete -ADObject $existingOU -Identity $existingOU.DistinguishedName
 		}
 		#endregion Process Managed Containers
 	}

--- a/DomainManagement/functions/serviceaccounts/Invoke-DMServiceAccount.ps1
+++ b/DomainManagement/functions/serviceaccounts/Invoke-DMServiceAccount.ps1
@@ -166,6 +166,9 @@
 			$clear = @()
 			foreach ($change in $testItem.Changed) {
 				if (-not $change.NewValue -and 0 -ne $change.NewValue) { $clear += $change.Property }
+				elseif ($change.Property -eq 'KerberosEncryptionType') {
+					$setParam.KerberosEncryptionType = $change.NewValue
+				}
 				else { $properties[$change.Property] = $change.NewValue }
 			}
 			if ($properties.Count -gt 0) { $setParam.Replace = $properties }

--- a/DomainManagement/functions/serviceaccounts/Test-DMServiceAccount.ps1
+++ b/DomainManagement/functions/serviceaccounts/Test-DMServiceAccount.ps1
@@ -141,8 +141,10 @@
 				}
 			}
 			$defaultProperties = 'DNSHostName', 'Description', 'ServicePrincipalName', 'DisplayName'
+			$unresolvedProperties = 'KerberosEncryptionType'
 			$changeObjects = foreach ($change in $changes) {
 				if ($change -in $defaultProperties) { New-Change -Type Update -Property $change -Previous $adObject.$change -NewValue ($serviceAccountDefinition.$change | Resolve-String @parameters) -Identity $resolvedName }
+				elseif ($change -in $unresolvedProperties) { New-Change -Type Update -Property $change -Previous $adObject.$change -NewValue $serviceAccountDefinition.$change -Identity $resolvedName }
 				else { New-Change -Type Update -Property $change -Previous $adObject.$change -NewValue $attributesObject.$change -Identity $resolvedName }
 			}
 			if ($changes) {

--- a/DomainManagement/internal/functions/New-TestResult.ps1
+++ b/DomainManagement/internal/functions/New-TestResult.ps1
@@ -1,5 +1,4 @@
-﻿function New-TestResult
-{
+﻿function New-TestResult {
 	<#
 	.SYNOPSIS
 		Generates a new test result object.
@@ -62,17 +61,16 @@
 		$ADObject
 	)
 	
-	process
-	{
+	process {
 		$object = [PSCustomObject]@{
-			PSTypeName = "DomainManagement.$ObjectType.TestResult"
-			Type = $Type
-			ObjectType = $ObjectType
-			Identity = $Identity
-			Changed = $Changed
-			Server = $Server
+			PSTypeName    = "DomainManagement.$ObjectType.TestResult"
+			Type          = $Type
+			ObjectType    = $ObjectType
+			Identity      = $Identity
+			Changed       = $Changed
+			Server        = $Server
 			Configuration = $Configuration
-			ADObject = $ADObject
+			ADObject      = $ADObject
 		}
 		Add-Member -InputObject $object -MemberType ScriptMethod -Name ToString -Value { $this.Identity } -Force
 		$object


### PR DESCRIPTION
- Upd: GroupPolicy - New state for group policies that are both out of date and have been modified outside of the system
- Upd: Organizational Units - TestResults with the DELETE action now show the full DN as identity
- Upd: Domain Level - Adding support to accept test results via pipeline for consistency reasons
- Fix: Service Accounts - Modifying the "KerberosEncryptionType" property of existing accounts fails
- Fix: Group Members - Identity fails to include member when trying to remove foreign security principals