### PR TITLE
1.8.188

### DIFF
--- a/DomainManagement/DomainManagement.psd1
+++ b/DomainManagement/DomainManagement.psd1
@@ -3,7 +3,7 @@
 	RootModule         = 'DomainManagement.psm1'
 	
 	# Version number of this module.
-	ModuleVersion      = '1.8.183'
+	ModuleVersion      = '1.8.188'
 	
 	# ID used to uniquely identify this module
 	GUID               = '0a405382-ebc2-445b-8325-541535810193'

--- a/DomainManagement/DomainManagement.psd1
+++ b/DomainManagement/DomainManagement.psd1
@@ -26,12 +26,12 @@
 	# Modules that must be imported into the global environment prior to importing
 	# this module
 	RequiredModules    = @(
-		@{ ModuleName = 'PSFramework'; ModuleVersion = '1.6.198' }
+		@{ ModuleName = 'PSFramework'; ModuleVersion = '1.7.270' }
 		
 		# Additional Dependencies, cannot declare due to bug in dependency handling in PS5.1
-		# @{ ModuleName = 'ADSec'; ModuleVersion = '0.2.1' }
+		# @{ ModuleName = 'ADSec'; ModuleVersion = '1.0.0' }
 		# @{ ModuleName = 'ResolveString'; ModuleVersion = '1.0.0' }
-		# @{ ModuleName = 'ADMF.Core'; ModuleVersion = '1.0.0' }
+		# @{ ModuleName = 'ADMF.Core'; ModuleVersion = '1.1.6' }
 	)
 	
 	# Assemblies that must be loaded prior to importing this module

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -2,6 +2,7 @@
 
 ## ???
 
+- Upd: ServiceAccount - extended KDS Root Key validation to accept presence of a gMSA as proof of existence, even if we cannot see the key.
 - Upd: GPLink - added result type "GpoMissing", refusing to update links when involved GPOs do not exist.
 - Fix: Password Generation - a very rare few passwords would not meet complexity requirements.
 

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -1,6 +1,6 @@
 ﻿# Changelog
 
-## ???
+## 1.8.188 (2023-02-10)
 
 - Upd: ServiceAccount - extended KDS Root Key validation to accept presence of a gMSA as proof of existence, even if we cannot see the key.
 - Upd: GPLink - added result type "GpoMissing", refusing to update links when involved GPOs do not exist.

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -4,6 +4,8 @@
 
 - Upd: ServiceAccount - extended KDS Root Key validation to accept presence of a gMSA as proof of existence, even if we cannot see the key.
 - Upd: GPLink - added result type "GpoMissing", refusing to update links when involved GPOs do not exist.
+- Upd: AccessRules - prevented 'Restore' results for the 'CREATOR OWNER' identity
+- Upd: AccessRules - protected accounts (AdminCount -eq 1) will attempt to take the same permissions as the AdminSDHolder object, rather than any configuration or schema defaults as their desired state.
 - Fix: Password Generation - a very rare few passwords would not meet complexity requirements.
 
 ## 1.8.183 (2022-11-15)

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -1,5 +1,10 @@
 ﻿# Changelog
 
+## ???
+
+- Upd: GPLink - added result type "GpoMissing", refusing to update links when involved GPOs do not exist.
+- Fix: Password Generation - a very rare few passwords would not meet complexity requirements.
+
 ## 1.8.183 (2022-11-15)
 
 - Upd: AccessRules - added alternative option to remove access rules

--- a/DomainManagement/en-us/strings.psd1
+++ b/DomainManagement/en-us/strings.psd1
@@ -74,6 +74,7 @@
 	'Invoke-DMExchange.WinRM.Failed'                                    = 'Failed to connect to {0} via WinRM' # $Server
 	
 	'Invoke-DMGPLink.Delete.AllEnabled'                                 = 'Removing all ({0}) policy links (all of which are enabled)' # $countActual
+	'Invoke-DMGPLink.GpoMissing'                                        = 'Skipping GP Link application for {0} - cannot resolve Group Policies "{1}"' # $testItem.ADObject, (($testItem.Changed | Where-Object Action -eq 'GpoMissing').Policy -join ", ")
 	'Invoke-DMGPLink.New'                                               = 'Linking {0} group policies (all new links)' # $countConfigured
 	'Invoke-DMGPLink.New.GpoNotFound'                                   = 'Unable to find Group POlicy Object: {0}' # (Resolve-String -Text $_.PolicyName)
 	'Invoke-DMGPLink.New.NewGPLinkString'                               = 'Finished gPLink string being applied to {0}: {1}' # $ADObject.DistinguishedName, $gpLinkString

--- a/DomainManagement/functions/gplinks/Invoke-DMGPLink.ps1
+++ b/DomainManagement/functions/gplinks/Invoke-DMGPLink.ps1
@@ -206,10 +206,12 @@
 					} -EnableException $EnableException.ToBool() -PSCmdlet $PSCmdlet -Continue
 				}
 				'Update' {
-					if (-not ($testItem.Changed | Where-Object Action -ne 'GpoMissing')) { continue }
 					Invoke-PSFProtectedCommand -ActionString 'Invoke-DMGPLink.Update.AllEnabled' -ActionStringValues $countConfigured, $countActual, $countNotInConfig -Target $testItem -ScriptBlock {
 						Update-Link @parameters -ADObject $testItem.ADObject -Configuration $testItem.Configuration -Disable $Disable -GpoNameMapping $gpoDisplayToDN -ErrorAction Stop
 					} -EnableException $EnableException.ToBool() -PSCmdlet $PSCmdlet -Continue
+				}
+				'GpoMissing' {
+					Write-PSFMessage -Level Warning -String 'Invoke-DMGPLink.GpoMissing' -StringValues $testItem.ADObject, (($testItem.Changed | Where-Object Action -eq 'GpoMissing').Policy -join ", ")
 				}
 			}
 		}

--- a/DomainManagement/functions/gplinks/Test-DMGPLink.ps1
+++ b/DomainManagement/functions/gplinks/Test-DMGPLink.ps1
@@ -302,13 +302,17 @@
 			}
 			#endregion Handle AD Object does not contain any links
 
-			$updates = Get-LinkUpdate -Configuration $ouDatum -ADObject $adObject -GpoDisplayToDN $gpoDisplayToDN
+			$updates = Get-LinkUpdate -Configuration $ouDatum -ADObject $adObject -GpoDisplayToDN $gpoDisplayToDN | Sort-Object {
+				if ($_.Action -eq "Delete") { 0 }
+				elseif ($_.Action -eq "Reorder") { 1 }
+				else { 2 }
+			}
+			if ($updates.Action -contains 'GpoMissing') {
+				New-TestResult @resultDefaults -Type 'GpoMissing' -Changed $updates
+				continue
+			}
 			if ($updates) {
-				New-TestResult @resultDefaults -Type 'Update' -Changed ($updates | Sort-Object {
-						if ($_.Action -eq "Delete") { 0 }
-						elseif ($_.Action -eq "Reorder") { 1 }
-						else { 2 }
-					})
+				New-TestResult @resultDefaults -Type 'Update' -Changed $updates
 			}
 		}
 

--- a/DomainManagement/internal/functions/New-Password.ps1
+++ b/DomainManagement/internal/functions/New-Password.ps1
@@ -45,9 +45,13 @@
 	}
 	process
 	{
-		$letters = foreach ($number in (1..$Length)) {
-			$characters[(($number % 4) + (1..4 | Get-Random))] | Get-Random
+		$letters = foreach ($number in (5..$Length)) {
+			$characters[(($number % 4) + (0..4 | Get-Random))] | Get-Random
 		}
+		0,1,2,3 | ForEach-Object {
+			$letters += $characters[$_] | Get-Random
+		}
+		$letters = $letters | Sort-Object { Get-Random }
 		if ($AsSecureString) { $letters -join "" | ConvertTo-SecureString -AsPlainText -Force }
 		else { $letters -join "" }
 	}

--- a/DomainManagement/internal/functions/Test-DmKdsRootKey.ps1
+++ b/DomainManagement/internal/functions/Test-DmKdsRootKey.ps1
@@ -34,6 +34,7 @@
 	begin
 	{
 		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include ComputerName, Credential
+		$adParameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include ComputerName, Credential -Remap @{ ComputerName = 'Server' }
 	}
 	process
 	{
@@ -45,6 +46,11 @@
 			$_.EffectiveTime -LT (Get-Date).AddHours(-10) -and
 			$_.DomainController -match ",OU=[^,]+,$($domain.DistinguishedName)$"
 		}) { return $true }
+
+		# If at least one gMSA exists, we can know it exists, even if we cannot see the KDS Root Key
+		if (Get-ADServiceAccount @adParameters -Filter * -ResultSetSize 1) {
+			return $true
+		}
 		
 		$paramGetPSFUserChoice = @{
 			Caption = 'No active KDS Root Key Detected'

--- a/DomainManagement/internal/functions/acl_ace/Get-AdminSDHolderRules.ps1
+++ b/DomainManagement/internal/functions/acl_ace/Get-AdminSDHolderRules.ps1
@@ -1,0 +1,37 @@
+﻿function Get-AdminSDHolderRules {
+	<#
+	.SYNOPSIS
+		Returns the access rules applied to the AdminSDHolder object.
+	
+	.DESCRIPTION
+		Returns the access rules applied to the AdminSDHolder object.
+		Used in workflows comparing privileges on the AdminSDHolder object.
+	
+	.PARAMETER Server
+		The server / domain to work with.
+	
+	.PARAMETER Credential
+		The credentials to use for this operation.
+	
+	.EXAMPLE
+		PS C:\> Get-AdminSDHolderRules
+
+		Returns the access rules applied to the AdminSDHolder object of the current domain.
+	#>
+	[CmdletBinding()]
+	param (
+		[PSFComputer]
+		$Server,
+
+		[PSCredential]
+		$Credential
+	)
+
+	begin {
+		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
+	}
+	process {
+		$systemContainer = (Get-ADDomain @parameters).SystemsContainer
+		(Get-AdsAcl -Path "CN=AdminSDHolder,$systemContainer" @parameters).Access
+	}
+}

--- a/DomainManagement/internal/functions/acl_ace/Get-AdminSDHolderRules.ps1
+++ b/DomainManagement/internal/functions/acl_ace/Get-AdminSDHolderRules.ps1
@@ -18,6 +18,7 @@
 
 		Returns the access rules applied to the AdminSDHolder object of the current domain.
 	#>
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "")]
 	[CmdletBinding()]
 	param (
 		[PSFComputer]


### PR DESCRIPTION
- Upd: ServiceAccount - extended KDS Root Key validation to accept presence of a gMSA as proof of existence, even if we cannot see the key.
- Upd: GPLink - added result type "GpoMissing", refusing to update links when involved GPOs do not exist.
- Upd: AccessRules - prevented 'Restore' results for the 'CREATOR OWNER' identity
- Upd: AccessRules - protected accounts (AdminCount -eq 1) will attempt to take the same permissions as the AdminSDHolder object, rather than any configuration or schema defaults as their desired state.
- Fix: Password Generation - a very rare few passwords would not meet complexity requirements.