### PR TITLE
1.8.199

### DIFF
--- a/DomainManagement/DomainManagement.psd1
+++ b/DomainManagement/DomainManagement.psd1
@@ -3,7 +3,7 @@
 	RootModule         = 'DomainManagement.psm1'
 	
 	# Version number of this module.
-	ModuleVersion      = '1.8.198'
+	ModuleVersion      = '1.8.199'
 	
 	# ID used to uniquely identify this module
 	GUID               = '0a405382-ebc2-445b-8325-541535810193'

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -1,5 +1,9 @@
 ﻿# Changelog
 
+## 1.8.199 (2023-09-27)
+
+- Fix: Groups - When renaming a group from a previous name, it will not find other updates to apply
+
 ## 1.8.198 (2023-05-15)
 
 - Upd: Acl - Will no longer try to enable inheritance for objects protected under the AdminSDHolder

--- a/DomainManagement/functions/domainlevel/Test-DMDomainLevel.ps1
+++ b/DomainManagement/functions/domainlevel/Test-DMDomainLevel.ps1
@@ -52,7 +52,9 @@
 		if ($domain.DomainMode -lt $desiredLevel)
 		{
 			New-TestResult -ObjectType DomainLevel -Type Raise -Identity $domain -Server $Server -Configuration ([pscustomobject]$tempConfiguration) -ADObject $domain -Changed (
-				New-AdcChange -Property DomainLevel -OldValue $domain.DomainMode -NewValue $tempConfiguration['DesiredLevel'] -Identity $domain -Type DomainLevel
+				New-AdcChange -Property DomainLevel -OldValue $domain.DomainMode -NewValue $tempConfiguration['DesiredLevel'] -Identity $domain -Type DomainLevel -ToString {
+					{ '{0}: {1} -> {2}' -f $this.Identity, $this.Old, $this.New }
+				}
 			)
 		}
 	}

--- a/DomainManagement/functions/groups/Register-DMGroup.ps1
+++ b/DomainManagement/functions/groups/Register-DMGroup.ps1
@@ -25,7 +25,7 @@
 	
 	.PARAMETER Scope
 		The scope of the group.
-		Use DomainLocal for groups that grrant direct permissions and Global for role groups.
+		Use DomainLocal for groups that grant direct permissions and Global for role groups.
 
 	.PARAMETER Category
 		Whether the group should be a security group or a distribution group.


### PR DESCRIPTION
- Fix: Groups - When renaming a group from a previous name, it will not find other updates to apply