### PR TITLE
1.9.210

### DIFF
--- a/DomainManagement/DomainManagement.psd1
+++ b/DomainManagement/DomainManagement.psd1
@@ -3,7 +3,7 @@
 	RootModule         = 'DomainManagement.psm1'
 	
 	# Version number of this module.
-	ModuleVersion      = '1.8.205'
+	ModuleVersion      = '1.9.210'
 	
 	# ID used to uniquely identify this module
 	GUID               = '0a405382-ebc2-445b-8325-541535810193'
@@ -26,7 +26,7 @@
 	# Modules that must be imported into the global environment prior to importing
 	# this module
 	RequiredModules    = @(
-		@{ ModuleName = 'PSFramework'; ModuleVersion = '1.10.318' }
+		@{ ModuleName = 'PSFramework'; ModuleVersion = '1.12.346' }
 		
 		# Additional Dependencies, cannot declare due to bug in dependency handling in PS5.1
 		# @{ ModuleName = 'ADSec'; ModuleVersion = '1.0.0' }

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -1,5 +1,13 @@
 ﻿# Changelog
 
+## 1.9.210 (2024-12-13)
+
+- Upd: Content Mode - added ability to exclude individual Components from constrained Content Mode
+- Upd: GroupMembers - extended membership scan for all groups under management, not just those with an explicit configuration entry
+- Fix: Users - stopped update results when not defining GivenName and Surname
+- Fix: Get-DMGroupMembership - ignores `-Name` parameter
+- Fix: Unregister-DMGroupMembership - fails to unregister processing modes
+
 ## 1.8.205 (2024-10-22)
 
 - Upd: Exchange - added extra validation to successful deployment runs

--- a/DomainManagement/en-us/strings.psd1
+++ b/DomainManagement/en-us/strings.psd1
@@ -190,6 +190,7 @@
 	'Resolve-PolicyRevision.Result.Result.SuccessNotYetManaged'         = 'Policy found: {0}. Has not yet been managed, will need to be overwritten.' # $Policy.DisplayName
 	'Resolve-PolicyRevision.Result.Success'                             = 'Found GPO: {0}. Last export ID: {1}. Last updated on {2}' # $Policy.DisplayName, $result.ExportID, $result.Timestamp
 	
+	'Set-DMContentMode.Error.UnknownExcludedComponent'                  = 'Error excluding a Component from the Domain Content Mode. Unexpected Component: {0}. Ensure the Component specified not only exists, but also supports being excluded from Domain Content Mode.' # $pair.Key
 	'Set-DMRedForestContext.Connection.Failed'                          = 'Failed to connect to {0}' # $Server
 	
 	'Test-DMAccessRule.DefaultPermission.Failed'                        = 'Failed to retrieve default permissions from Schema when connecting to {0}' # $Server

--- a/DomainManagement/functions/acls/Test-DMAcl.ps1
+++ b/DomainManagement/functions/acls/Test-DMAcl.ps1
@@ -139,6 +139,8 @@
 		}
 		#endregion processing configuration
 
+		if ($script:contentMode.ExcludeComponents.ACLs) { return }
+
 		#region check if all ADObjects are managed
 		$foundADObjects = foreach ($searchBase in (Resolve-ContentSearchBase @parameters -NoContainer)) {
 			Get-ADObject @parameters -LDAPFilter '(objectCategory=*)' -SearchBase $searchBase.SearchBase -SearchScope $searchBase.SearchScope -Properties AdminCount

--- a/DomainManagement/functions/gplinks/Test-DMGPLink.ps1
+++ b/DomainManagement/functions/gplinks/Test-DMGPLink.ps1
@@ -59,7 +59,7 @@
 					$ous[$resolvedOU].ProcessingMode = 'Constrained'
 				}
 			}
-			#region Explicit OUs
+			#endregion Explicit OUs
 			
 			#region Filter-Based OUs
 			foreach ($filter in $script:groupPolicyLinksDynamic.Keys) {
@@ -315,6 +315,9 @@
 				New-TestResult @resultDefaults -Type 'Update' -Changed $updates
 			}
 		}
+		#endregion Process Configuration
+
+		if ($script:contentMode.ExcludeComponents.GPLinks) { return }
 
 		#region Process Managed Estate
 		# OneLevel needs to be converted to base, as searching for OUs with "OneLevel" would return unmanaged OUs.

--- a/DomainManagement/functions/groupmemberships/Get-DMGroupMembership.ps1
+++ b/DomainManagement/functions/groupmemberships/Get-DMGroupMembership.ps1
@@ -25,7 +25,7 @@
 		$Group = '*',
 
 		[string]
-		$Name = '*'
+		$Name
 	)
 	
 	process
@@ -35,6 +35,7 @@
 
 			if ($script:groupMemberShips[$key].Count -gt 0) {
 				foreach ($innerKey in $script:groupMemberShips[$key].Keys) {
+					if ($Name -and $innerKey -notlike $Name) { continue }
 					$script:groupMemberShips[$key][$innerKey]
 				}
 			}

--- a/DomainManagement/functions/groupmemberships/Register-DMGroupMembership.ps1
+++ b/DomainManagement/functions/groupmemberships/Register-DMGroupMembership.ps1
@@ -131,6 +131,7 @@
             $script:groupMemberShips[$Group]['__Configuration'] = [PSCustomObject]@{
                 PSTypeName     = 'DomainManagement.GroupMembership.Configuration'
                 ProcessingMode = $GroupProcessingMode
+				Group = $Group
             }
         }
     }

--- a/DomainManagement/functions/groupmemberships/Test-DMGroupMembership.ps1
+++ b/DomainManagement/functions/groupmemberships/Test-DMGroupMembership.ps1
@@ -68,6 +68,7 @@
 		}
 
 		function New-MemberRemovalResult {
+			[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
 			[CmdletBinding()]
 			param (
 				$ADObject,

--- a/DomainManagement/functions/groupmemberships/Unregister-DMGroupMembership.ps1
+++ b/DomainManagement/functions/groupmemberships/Unregister-DMGroupMembership.ps1
@@ -15,6 +15,9 @@
 	
 	.PARAMETER Group
 		The group being granted membership in.
+
+	.PARAMETER ProcessingMode
+		The processing mode to apply for the group's membership management.
 	
 	.EXAMPLE
 		PS C:\> Get-DMGroupMembership | Unregister-DMGroupMembership
@@ -23,23 +26,35 @@
 	#>
 	[CmdletBinding()]
 	param (
-		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Identity')]
 		[string]
 		$Name,
 
-		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Identity')]
 		[ValidateSet('User', 'Group', 'foreignSecurityPrincipal', 'Computer', '<Empty>')]
 		[string]
 		$ItemType,
 
-		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Processing')]
+		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Identity')]
 		[string]
-		$Group
+		$Group,
+
+		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Processing')]
+		[string]
+		$ProcessingMode
 	)
 	
 	process
 	{
 		if (-not $script:groupMemberShips[$Group]) { return }
+		if ($ProcessingMode) {
+			$null = $script:groupMemberShips[$Group].Remove('__Configuration')
+			if (-not $script:groupMemberShips[$Group].Count) {
+				$null = $script:groupMemberShips.Remove($Group)
+			}
+			return
+		}
 		if ($Name -eq '<empty>') {
 			$null = $script:groupMemberShips.Remove($Group)
 			return

--- a/DomainManagement/functions/groups/Test-DMGroup.ps1
+++ b/DomainManagement/functions/groups/Test-DMGroup.ps1
@@ -124,6 +124,8 @@
 			#endregion Existing Groups, might need updates
 		}
 
+		if ($script:contentMode.ExcludeComponents.Groups) { return }
+
 		$foundGroups = foreach ($searchBase in (Resolve-ContentSearchBase @parameters)) {
 			Get-ADGroup @parameters -LDAPFilter '(!(isCriticalSystemObject=TRUE))' -SearchBase $searchBase.SearchBase -SearchScope $searchBase.SearchScope
 		}

--- a/DomainManagement/functions/organizationalunits/Test-DMOrganizationalUnit.ps1
+++ b/DomainManagement/functions/organizationalunits/Test-DMOrganizationalUnit.ps1
@@ -105,6 +105,8 @@
 		}
 		#endregion Process Configured OUs
 
+		if ($script:contentMode.ExcludeComponents.OrganizationalUnits) { return }
+
 		#region Process Managed Containers
 		$foundOUs = foreach ($searchBase in (Resolve-ContentSearchBase @parameters -IgnoreMissingSearchbase)) {
 			Get-ADOrganizationalUnit @parameters -LDAPFilter '(!(isCriticalSystemObject=TRUE))' -SearchBase $searchBase.SearchBase -SearchScope $searchBase.SearchScope -Properties nTSecurityDescriptor | Where-Object DistinguishedName -Ne $searchBase.SearchBase

--- a/DomainManagement/functions/serviceaccounts/Test-DMServiceAccount.ps1
+++ b/DomainManagement/functions/serviceaccounts/Test-DMServiceAccount.ps1
@@ -238,6 +238,8 @@
 		}
 		#endregion Process Configured Objects
 		
+		if ($script:contentMode.ExcludeComponents.ServiceAccounts) { return }
+
 		#region Process Non-Configuted AD-Objects
 		$foundServiceAccounts = foreach ($searchBase in (Resolve-ContentSearchBase @parameters)) {
 			Get-ADServiceAccount @parameters -LDAPFilter '(!(isCriticalSystemObject=TRUE))' -SearchBase $searchBase.SearchBase -SearchScope $searchBase.SearchScope

--- a/DomainManagement/functions/users/Test-DMUser.ps1
+++ b/DomainManagement/functions/users/Test-DMUser.ps1
@@ -110,8 +110,8 @@
 				AsUpdate = $true
 				Type = 'User'
 			}
-			Compare-Property @compare -Property GivenName -Resolve
-			Compare-Property @compare -Property Surname -Resolve
+			Compare-Property @compare -Property GivenName -Resolve -AsString
+			Compare-Property @compare -Property Surname -Resolve -AsString
 			if ($null -ne $userDefinition.Description) { Compare-Property @compare -Property Description -Resolve }
 			Compare-Property @compare -Property PasswordNeverExpires
 			Compare-Property @compare -Property UserPrincipalName -Resolve

--- a/DomainManagement/internal/scripts/variables.ps1
+++ b/DomainManagement/internal/scripts/variables.ps1
@@ -111,6 +111,16 @@ $script:contentMode = [PSCustomObject]@{
     Exclude = @()
     UserExcludePattern = @()
 	RemoveUnknownWmiFilter = $false
+
+	# Note: Also update the help on Set-DMContentMode and on the website Content Mode documentation, when adding new entries here.
+	ExcludeComponents = @{
+		ACLs = $false
+		GPLinks = $false
+		GroupMembership = $false
+		Groups = $false
+		OrganizationalUnits = $false
+		ServiceAccounts = $false
+	}
 }
 $script:contentSearchBases = [PSCustomObject]@{
     Include = @()


### PR DESCRIPTION
- Upd: Content Mode - added ability to exclude individual Components from constrained Content Mode
- Upd: GroupMembers - extended membership scan for all groups under management, not just those with an explicit configuration entry
- Fix: Users - stopped update results when not defining GivenName and Surname
- Fix: Get-DMGroupMembership - ignores `-Name` parameter
- Fix: Unregister-DMGroupMembership - fails to unregister processing modes