### PR TITLE
1.9.218

### DIFF
--- a/DomainManagement/DomainManagement.psd1
+++ b/DomainManagement/DomainManagement.psd1
@@ -3,7 +3,7 @@
 	RootModule         = 'DomainManagement.psm1'
 	
 	# Version number of this module.
-	ModuleVersion      = '1.9.210'
+	ModuleVersion      = '1.9.218'
 	
 	# ID used to uniquely identify this module
 	GUID               = '0a405382-ebc2-445b-8325-541535810193'

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -1,6 +1,6 @@
 ﻿# Changelog
 
-## ???
+## 1.9.218 (2025-05-28)
 
 - Upd: Organizational Units - added ability to define GP inheritance blocking. Defaults to NOT block.
 - Upd: Users - added ability to specify custom attributes/properties for users.

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -2,9 +2,14 @@
 
 ## ???
 
+- Upd: Organizational Units - added ability to define GP inheritance blocking. Defaults to NOT block.
+- Upd: Users - added ability to specify custom attributes/properties for users.
 - Upd: AccessRules - added configuration property showing what context it comes from.
 - Upd: AccessRules - will ignore Group Policy AD Objects - they are governed by the GP Permissions component
 - Fix: AccessRules - objects that have no default permission generate an empty restore result
+- Fix: GroupPolicy - Reports wrong Policyname when failing to read GPO tracking file
+- Fix: GroupPolicy - Fails with the wrong error when the GPO no longer has a matching directory in SYSVOL.
+- Fix: GroupMemberships - Cannot unregister group memberships assigned based on categories.
 
 ## 1.9.210 (2024-12-13)
 

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -1,5 +1,11 @@
 ﻿# Changelog
 
+## ???
+
+- Upd: AccessRules - added configuration property showing what context it comes from.
+- Upd: AccessRules - will ignore Group Policy AD Objects - they are governed by the GP Permissions component
+- Fix: AccessRules - objects that have no default permission generate an empty restore result
+
 ## 1.9.210 (2024-12-13)
 
 - Upd: Content Mode - added ability to exclude individual Components from constrained Content Mode

--- a/DomainManagement/functions/AccessRule/Register-DMAccessRule.ps1
+++ b/DomainManagement/functions/AccessRule/Register-DMAccessRule.ps1
@@ -62,6 +62,11 @@
 		By default, Test-DMAccessRule will generate a "FixConfig" result for accessrules that have been explicitly defined but are also part of the Schema Default permissions.
 		If this setting is enabled, this result object is suppressed.
 
+	.PARAMETER ContextName
+		The name of the context defining the setting.
+		This allows determining the configuration set that provided this setting.
+		Used by the ADMF, available to any other configuration management solution.
+
 	.EXAMPLE
 		PS C:\> Register-DMAccessRule -ObjectCategory DomainControllers -Identity '%DomainName%\Domain Admins' -ActiveDirectoryRights GenericAll
 
@@ -111,7 +116,10 @@
 		$Present = 'true',
 
 		[bool]
-		$NoFixConfig = $false
+		$NoFixConfig = $false,
+
+		[string]
+		$ContextName = '<Undefined>'
 	)
 	
 	process {
@@ -130,6 +138,7 @@
 					Optional              = $Optional
 					Present               = $Present
 					NoFixConfig           = $NoFixConfig
+					ContextName           = $ContextName
 				}
 			}
 			'Category' {
@@ -146,6 +155,7 @@
 					Optional              = $Optional
 					Present               = $Present
 					NoFixConfig           = $NoFixConfig
+					ContextName           = $ContextName
 				}
 			}
 		}

--- a/DomainManagement/functions/AccessRule/Test-DMAccessRule.ps1
+++ b/DomainManagement/functions/AccessRule/Test-DMAccessRule.ps1
@@ -193,6 +193,9 @@
 				# Prevent duplicate processing
 				if ($processed[$foundADObject.DistinguishedName]) { continue }
 				$processed[$foundADObject.DistinguishedName] = $true
+
+				# Skip GPOs, as those are handled within the GP Permissions Component
+				if ($foundADObject.DistinguishedName -match 'CN={[^,]+},CN=Policies,CN=System,') { continue }
 	
 				# Skip items that were defined in configuration, they were already processed
 				if ($foundADObject.DistinguishedName -in $resolvedConfiguredObjects) { continue }

--- a/DomainManagement/functions/gplinks/Register-DMGPLink.ps1
+++ b/DomainManagement/functions/gplinks/Register-DMGPLink.ps1
@@ -50,6 +50,11 @@
 	.PARAMETER Present
 		Whether the link should be present at all.
 		Relevant in additive mode, to retain the capability to delete undesired links.
+
+	.PARAMETER ContextName
+		The name of the context defining the setting.
+		This allows determining the configuration set that provided this setting.
+		Used by the ADMF, available to any other configuration management solution.
 	
 	.EXAMPLE
 		PS C:\> Get-Content $configPath | ConvertFrom-Json | Write-Output | Register-DMGPLink
@@ -91,7 +96,10 @@
 
 		[Parameter(ValueFromPipelineByPropertyName = $true)]
 		[bool]
-		$Present = $true
+		$Present = $true,
+		
+		[string]
+		$ContextName = '<Undefined>'
 	)
 	
 	process {
@@ -109,6 +117,7 @@
 					State              = $State
 					ProcessingMode     = $ProcessingMode
 					Present            = $Present
+					ContextName        = $ContextName
 				}
 			}
 			'Filter' {
@@ -124,6 +133,7 @@
 					State          = $State
 					ProcessingMode = $ProcessingMode
 					Present        = $Present
+					ContextName    = $ContextName
 				}
 			}
 		}

--- a/DomainManagement/functions/groupmemberships/Register-DMGroupMembership.ps1
+++ b/DomainManagement/functions/groupmemberships/Register-DMGroupMembership.ps1
@@ -1,5 +1,5 @@
 ﻿function Register-DMGroupMembership {
-    <#
+	<#
 	.SYNOPSIS
 		Registers a group membership assignment as desired state.
 	
@@ -56,83 +56,84 @@
 		Imports all defined groupmemberships from the targeted json configuration file.
 #>
 	
-    [CmdletBinding(DefaultParameterSetName = 'Entry')]
-    param (
-        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Entry')]
-        [string]
-        $Name,
+	[CmdletBinding(DefaultParameterSetName = 'Entry')]
+	param (
+		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Entry')]
+		[string]
+		$Name,
 		
-        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Entry')]
-        [string]
-        $Domain,
+		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Entry')]
+		[string]
+		$Domain,
 		
-        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Entry')]
-        [ValidateSet('User', 'Group', 'foreignSecurityPrincipal', 'Computer', 'msDS-GroupManagedServiceAccount')]
-        [string]
-        $ItemType,
+		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Entry')]
+		[ValidateSet('User', 'Group', 'foreignSecurityPrincipal', 'Computer', 'msDS-GroupManagedServiceAccount')]
+		[string]
+		$ItemType,
 
-        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Category')]
-        [string]
-        $ObjectCategory,
+		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Category')]
+		[string]
+		$ObjectCategory,
 		
-        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Entry')]
-        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Category')]
-        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Empty')]
-        [string]
-        $Group,
+		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Entry')]
+		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Category')]
+		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Empty')]
+		[string]
+		$Group,
 		
-        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Empty')]
-        [bool]
-        $Empty,
+		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Empty')]
+		[bool]
+		$Empty,
 		
-        [Parameter(ValueFromPipelineByPropertyName = $true)]
-        [ValidateSet('Default', 'MayBeMember', 'MemberIfExists', 'MayBeMemberIfExists')]
-        [string]
-        $Mode = 'Default',
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
+		[ValidateSet('Default', 'MayBeMember', 'MemberIfExists', 'MayBeMemberIfExists')]
+		[string]
+		$Mode = 'Default',
 		
-        [Parameter(ValueFromPipelineByPropertyName = $true)]
-        [ValidateSet('Constrained', 'Additive')]
-        [string]
-        $GroupProcessingMode,
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
+		[ValidateSet('Constrained', 'Additive')]
+		[string]
+		$GroupProcessingMode,
 		
-        [string]
-        $ContextName = '<Undefined>'
-    )
+		[string]
+		$ContextName = '<Undefined>'
+	)
 	
-    process {
-        if (-not $script:groupMemberShips[$Group]) {
-            $script:groupMemberShips[$Group] = @{ }
-        }
-        if ($Name) {
-            $script:groupMemberShips[$Group]["$($ItemType):$($Name)"] = [PSCustomObject]@{
-                PSTypeName  = 'DomainManagement.GroupMembership'
-                Name        = $Name
-                Domain      = $Domain
-                ItemType    = $ItemType
-                Group       = $Group
-                Mode        = $Mode
-                ContextName = $ContextName
-            }
-        }
-        elseif ($ObjectCategory) {
-            $script:groupMemberShips[$Group]["ObjectCategory:$($ObjectCategory)"] = [PSCustomObject]@{
-                PSTypeName  = 'DomainManagement.GroupMembership'
-                Category    = $ObjectCategory
-                Group       = $Group
-                Mode        = $Mode
-                ContextName = $ContextName
-            }
-        }
-        elseif ($Empty) {
-            $script:groupMemberShips[$Group] = @{ }
-        }
+	process {
+		if (-not $script:groupMemberShips[$Group]) {
+			$script:groupMemberShips[$Group] = @{ }
+		}
+		if ($Name) {
+			$script:groupMemberShips[$Group]["$($ItemType):$($Name)"] = [PSCustomObject]@{
+				PSTypeName  = 'DomainManagement.GroupMembership'
+				Name        = $Name
+				Domain      = $Domain
+				ItemType    = $ItemType
+				Group       = $Group
+				Mode        = $Mode
+				ContextName = $ContextName
+			}
+		}
+		elseif ($ObjectCategory) {
+			$script:groupMemberShips[$Group]["ObjectCategory:$($ObjectCategory)"] = [PSCustomObject]@{
+				PSTypeName  = 'DomainManagement.GroupMembership'
+				Category    = $ObjectCategory
+				Group       = $Group
+				Mode        = $Mode
+				ContextName = $ContextName
+			}
+		}
+		elseif ($Empty) {
+			$script:groupMemberShips[$Group] = @{ }
+		}
 		
-        if ($GroupProcessingMode) {
-            $script:groupMemberShips[$Group]['__Configuration'] = [PSCustomObject]@{
-                PSTypeName     = 'DomainManagement.GroupMembership.Configuration'
-                ProcessingMode = $GroupProcessingMode
-				Group = $Group
-            }
-        }
-    }
+		if ($GroupProcessingMode) {
+			$script:groupMemberShips[$Group]['__Configuration'] = [PSCustomObject]@{
+				PSTypeName     = 'DomainManagement.GroupMembership.Configuration'
+				ProcessingMode = $GroupProcessingMode
+				Group          = $Group
+				ContextName    = $ContextName
+			}
+		}
+	}
 }

--- a/DomainManagement/functions/groupmemberships/Unregister-DMGroupMembership.ps1
+++ b/DomainManagement/functions/groupmemberships/Unregister-DMGroupMembership.ps1
@@ -35,8 +35,13 @@
 		[string]
 		$ItemType,
 
+		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Category')]
+		[string]
+		$Category,
+
 		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Processing')]
 		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Identity')]
+		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Category')]
 		[string]
 		$Group,
 
@@ -57,6 +62,10 @@
 		}
 		if ($Name -eq '<empty>') {
 			$null = $script:groupMemberShips.Remove($Group)
+			return
+		}
+		if ($Category) {
+			$null = $script:groupMemberShips.Remove("ObjectCategory:$Category")
 			return
 		}
 		if (-not $script:groupMemberShips[$Group]["$($ItemType):$($Name)"]) { return }

--- a/DomainManagement/functions/groupmemberships/Unregister-DMGroupMembership.ps1
+++ b/DomainManagement/functions/groupmemberships/Unregister-DMGroupMembership.ps1
@@ -12,6 +12,9 @@
 	
 	.PARAMETER ItemType
 		The type of object the identity being granted group membership is.
+
+	.PARAMETER Category
+		The Object Category that defines the members.
 	
 	.PARAMETER Group
 		The group being granted membership in.

--- a/DomainManagement/functions/grouppolicies/Test-DMGroupPolicy.ps1
+++ b/DomainManagement/functions/grouppolicies/Test-DMGroupPolicy.ps1
@@ -81,7 +81,7 @@
 			}
 			# Resolve-PolicyRevision updates the content of $groupPolicy without producing output
 			try { Resolve-PolicyRevision -Policy $groupPolicy -Session $session }
-			catch { Write-PSFMessage -Level Warning -String 'Test-DMGroupPolicy.PolicyRevision.Lookup.Failed' -StringValues $allPolicies.DisplayName -ErrorRecord $_ -EnableException $EnableException.ToBool() }
+			catch { Write-PSFMessage -Level Warning -String 'Test-DMGroupPolicy.PolicyRevision.Lookup.Failed' -StringValues $groupPolicy.DisplayName -ErrorRecord $_ -EnableException $EnableException.ToBool() }
 		}
 		$desiredHash = @{ }
 		$policyHash = @{ }

--- a/DomainManagement/functions/organizationalunits/Register-DMOrganizationalUnit.ps1
+++ b/DomainManagement/functions/organizationalunits/Register-DMOrganizationalUnit.ps1
@@ -21,6 +21,10 @@
 	.PARAMETER Optional
 		By default, organizational units must exist if defined.
 		Setting this to true makes them optional instead - they will not be created but are tolerated if they exist.
+
+	.PARAMETER BlockGPInheritance
+		Whether GP Inheritance should be blocked on this OU.
+		By default, Group Policy Inheritance is enabled.
 	
 	.PARAMETER OldNames
 		Previous names the OU had.
@@ -54,6 +58,10 @@
 		[Parameter(ValueFromPipelineByPropertyName = $true)]
 		[bool]
 		$Optional,
+		
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
+		[bool]
+		$BlockGPInheritance,
 
 		[string[]]
 		$OldNames = @(),
@@ -65,14 +73,15 @@
 	process {
 		$distinguishedName = 'OU={0},{1}' -f $Name, $Path
 		$script:organizationalUnits[$distinguishedName] = [PSCustomObject]@{
-			PSTypeName        = 'DomainManagement.OrganizationalUnit'
-			DistinguishedName = $distinguishedName
-			Name              = $Name
-			Description       = $Description
-			Path              = $Path
-			Optional          = $Optional
-			OldNames          = $OldNames
-			Present           = $Present
+			PSTypeName         = 'DomainManagement.OrganizationalUnit'
+			DistinguishedName  = $distinguishedName
+			Name               = $Name
+			Description        = $Description
+			Path               = $Path
+			Optional           = $Optional
+			BlockGPInheritance = $BlockGPInheritance
+			OldNames           = $OldNames
+			Present            = $Present
 		}
 	}
 }

--- a/DomainManagement/functions/other/Get-DMObjectDefaultPermission.ps1
+++ b/DomainManagement/functions/other/Get-DMObjectDefaultPermission.ps1
@@ -89,6 +89,10 @@
 					}
 					$accessRule
 				}
+				
+				# Workaround to prevent serialization issue. The $null of a loop return converts into an empty PSCustomObject, rather than actually being null, when serialized and deserialized.
+				if (-not $access) { $access = $null }
+
 				[PSCustomObject]@{
 					Class = $class.lDAPDisplayName
 					Access = $access

--- a/DomainManagement/functions/users/Invoke-DMUser.ps1
+++ b/DomainManagement/functions/users/Invoke-DMUser.ps1
@@ -90,6 +90,13 @@
 						if ($testItem.Configuration.Description) { $newParameters['Description'] = Resolve-String -Text $testItem.Configuration.Description }
 						if ($testItem.Configuration.GivenName) { $newParameters['GivenName'] = Resolve-String -Text $testItem.Configuration.GivenName }
 						if ($testItem.Configuration.Surname) { $newParameters['Surname'] = Resolve-String -Text $testItem.Configuration.Surname }
+
+						# Other Attributes
+						$otherAttributes = @{}
+						foreach ($attribute in $testItem.Configuration.Attributes.Keys) { $otherAttributes[$attribute] = $testItem.Configuration.Attributes.$attribute }
+						foreach ($attribute in $testItem.Configuration.AttributesResolved.Keys) { $otherAttributes[$attribute] = Resolve-String -Text $testItem.Configuration.AttributesResolved.$attribute }
+						if ($otherAttributes.Count -gt 0) { $newParameters.OtherAttributes = $otherAttributes }
+
 						New-ADUser @newParameters
 					} -EnableException $EnableException.ToBool() -PSCmdlet $PSCmdlet -Continue
 				}
@@ -116,7 +123,7 @@
 					}
 					$changes = @{ }
 					foreach ($change in $testItem.Changed) {
-						if ($change.Property -notin 'GivenName','Surname','Description','UserPrincipalName') { continue }
+						if ($change.Property -in 'Enabled','Name','PasswordNeverExpires', 'Path') { continue }
 						switch ($change.Property) {
 							Surname { $changes['sn'] = $change.New }
 							default { $changes[$change.Property] = $change.New }

--- a/DomainManagement/functions/users/Register-DMUser.ps1
+++ b/DomainManagement/functions/users/Register-DMUser.ps1
@@ -46,6 +46,16 @@
 		The organizational unit the user should be placed in.
 		Subject to string insertion.
 
+	.PARAMETER Attributes
+		Additional attributes that should be applied to the user.
+		Can be any attribute available to users, but some data types may not work out as intended.
+		NOT Subject to string insertion.
+
+	.PARAMETER AttributesResolved
+		Additional attributes that should be applied to the user.
+		Can be any attribute available to users, but some data types may not work out as intended.
+		Subject to string insertion.
+
 	.PARAMETER Enabled
 		Whether the user object should be enabled or disabled.
 		Defaults to: Undefined
@@ -107,7 +117,15 @@
 		[Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
 		[string]
 		$Path,
+
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
+		[hashtable]
+		$Attributes,
 		
+		[Parameter(ValueFromPipelineByPropertyName = $true)]
+		[hashtable]
+		$AttributesResolved,
+
 		[Parameter(ValueFromPipelineByPropertyName = $true)]
 		[PSFramework.Utility.TypeTransformationAttribute([string])]
 		[DomainManagement.TriBool]
@@ -142,6 +160,8 @@
 			PasswordNeverExpires = $PasswordNeverExpires.ToBool()
 			UserPrincipalName    = $UserPrincipalName
 			Path                 = $Path
+			Attributes           = $Attributes
+			AttributesResolved   = $AttributesResolved
 			Enabled              = $Enabled
 			Optional             = $Optional
 			OldNames             = $OldNames


### PR DESCRIPTION
- Upd: Organizational Units - added ability to define GP inheritance blocking. Defaults to NOT block.
- Upd: Users - added ability to specify custom attributes/properties for users.
- Upd: AccessRules - added configuration property showing what context it comes from.
- Upd: AccessRules - will ignore Group Policy AD Objects - they are governed by the GP Permissions component
- Fix: AccessRules - objects that have no default permission generate an empty restore result
- Fix: GroupPolicy - Reports wrong Policyname when failing to read GPO tracking file
- Fix: GroupPolicy - Fails with the wrong error when the GPO no longer has a matching directory in SYSVOL.
- Fix: GroupMemberships - Cannot unregister group memberships assigned based on categories.