### PR TITLE
1.9.234

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ TestResults/*
 
 # ignore the publishing Directory
 publish/*
+
+# Local Planning Folder
+planning/*

--- a/DomainManagement/DomainManagement.psd1
+++ b/DomainManagement/DomainManagement.psd1
@@ -3,7 +3,7 @@
 	RootModule         = 'DomainManagement.psm1'
 	
 	# Version number of this module.
-	ModuleVersion      = '1.9.228'
+	ModuleVersion      = '1.9.234'
 	
 	# ID used to uniquely identify this module
 	GUID               = '0a405382-ebc2-445b-8325-541535810193'
@@ -26,7 +26,7 @@
 	# Modules that must be imported into the global environment prior to importing
 	# this module
 	RequiredModules    = @(
-		@{ ModuleName = 'PSFramework'; ModuleVersion = '1.12.346' }
+		@{ ModuleName = 'PSFramework'; ModuleVersion = '1.13.416' }
 		
 		# Additional Dependencies, cannot declare due to bug in dependency handling in PS5.1
 		# @{ ModuleName = 'ADSec'; ModuleVersion = '1.0.0' }

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -1,10 +1,11 @@
 ﻿# Changelog
 
-## ???
+## 1.9.234 (2025-10-31)
 
-- Upd: Access Rules - Use the shared managed remoting feature, allowing configuring session options.
+- Upd: General - Use the shared managed remoting feature, allowing configuring session options.
 - Upd: AccessRules - when failing to resolve the identity of a principal on an existing access rule, the warning now reports the DN of the object
 - Upd: Exchange - accepts test results as input for invoke
+- Upd: GPLink - Supports cherry-picking results within a single OU.
 - Fix: GPOwner - Prints red error messages on screen when failing to resovle the owner
 - Fix: Groups - Ignores SamAccountName during creation of new groups
 

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -1,5 +1,13 @@
 ﻿# Changelog
 
+## ???
+
+- Upd: Access Rules - Use the shared managed remoting feature, allowing configuring session options.
+- Upd: AccessRules - when failing to resolve the identity of a principal on an existing access rule, the warning now reports the DN of the object
+- Upd: Exchange - accepts test results as input for invoke
+- Fix: GPOwner - Prints red error messages on screen when failing to resovle the owner
+- Fix: Groups - Ignores SamAccountName during creation of new groups
+
 ## 1.9.228 (2025-10-02)
 
 - Upd: Group Memberships - added option "ConfigOnly", allowing to define the group processing mode, without specifying any actual memberships.

--- a/DomainManagement/en-us/strings.psd1
+++ b/DomainManagement/en-us/strings.psd1
@@ -21,6 +21,7 @@
 	'Get-PermissionGuidMapping.Processing'                              = 'Processing Permission Guids for domain: {0} (This may take a while)' # $identity
 	
 	'Get-Principal.Resolution.Failed'                                   = 'Failed to resolve principal: SID {0} | Name {1} | ObjectClass {2} | Domain {3}' # $Sid, $Name, $ObjectClass, $Domain
+	'Get-Principal.Resolution.FailedWithTarget'                         = 'Failed to resolve principal: SID {0} | Name {1} | ObjectClass {2} | Domain {3} | Target {4}' # $Sid, $Name, $ObjectClass, $Domain, $Target
 	
 	'Get-SchemaGuidMapping.Processing'                                  = 'Processing Schema Guids for domain: {0} (This may take a while)' # $identity
 	

--- a/DomainManagement/en-us/strings.psd1
+++ b/DomainManagement/en-us/strings.psd1
@@ -77,7 +77,6 @@
 	'Invoke-DMGPLink.Delete.AllEnabled'                                 = 'Removing all ({0}) policy links (all of which are enabled)' # $countActual
 	'Invoke-DMGPLink.GpoMissing'                                        = 'Skipping GP Link application for {0} - cannot resolve Group Policies "{1}"' # $testItem.ADObject, (($testItem.Changed | Where-Object Action -eq 'GpoMissing').Policy -join ", ")
 	'Invoke-DMGPLink.New'                                               = 'Linking {0} group policies (all new links)' # $countConfigured
-	'Invoke-DMGPLink.New.GpoNotFound'                                   = 'Unable to find Group Policy Object: {0}' # (Resolve-String -Text $_.PolicyName)
 	'Invoke-DMGPLink.New.NewGPLinkString'                               = 'Finished gPLink string being applied to {0}: {1}' # $ADObject.DistinguishedName, $gpLinkString
 	'Invoke-DMGPLink.Update.AllEnabled'                                 = 'Updating GPLink - {0} links configured, {1} links present, {2} links present that are not in configuration (All present and undesired links are enabled)' # $countConfigured, $countActual, $countNotInConfig
 	'Invoke-DMGPLink.Update.Change'                                     = '  Link update: {0} - {1} ({2})' # $change.Action, $change.Policy, $ADObject.DistinguishedName

--- a/DomainManagement/functions/AccessRule/Test-DMAccessRule.ps1
+++ b/DomainManagement/functions/AccessRule/Test-DMAccessRule.ps1
@@ -160,7 +160,7 @@
 				$desiredPermissions = $script:accessRules[$key] | Convert-AccessRule @parameters -ADObject $adObject
 			}
 
-			$delta = Compare-AccessRules @parameters -ADRules ($adAclObject.Access | Convert-AccessRuleIdentity @parameters) -ConfiguredRules $desiredPermissions -DefaultRules $defaultPermissions -ADObject $adObject
+			$delta = Compare-AccessRules @parameters -ADRules ($adAclObject.Access | Convert-AccessRuleIdentity @parameters -Target $adAclObject.DistinguishedName) -ConfiguredRules $desiredPermissions -DefaultRules $defaultPermissions -ADObject $adObject
 
 			if ($delta) {
 				New-TestResult @resultDefaults -Type Update -Changed $delta -ADObject $adAclObject

--- a/DomainManagement/functions/gplinks/Invoke-DMGPLink.ps1
+++ b/DomainManagement/functions/gplinks/Invoke-DMGPLink.ps1
@@ -80,15 +80,29 @@
 				$ADObject,
 
 				[bool]
-				$Disable
+				$Disable,
+
+				$Changes,
+
+				$Definition
 			)
 			$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
 
-			if (-not $Disable) {
+			$newChanges = foreach ($change in $Definition) {
+				if ($change.Policy -notin $Changes.Policy) {
+					$change.ToLink()
+					continue
+				}
+				if (-not $Disable) { continue }
+
+				'[LDAP://{0};1]' -f $change.PolicyDN
+			}
+
+			if (-not $newChanges) {
 				Set-ADObject @parameters -Identity $ADObject -Clear gPLink -ErrorAction Stop
 				return
 			}
-			Set-ADObject @parameters -Identity $ADObject -Replace @{ gPLink = ($ADObject.gPLink -replace ";\d\]", ";1]") } -ErrorAction Stop -Confirm:$false
+			Set-ADObject @parameters -Identity $ADObject -Replace @{ gPLink = $newChanges -join '' } -ErrorAction Stop -Confirm:$false
 		}
 
 		function New-Link {
@@ -103,24 +117,11 @@
 
 				$ADObject,
 
-				$Configuration,
-
-				[Hashtable]
-				$GpoNameMapping
+				$Changes
 			)
 			$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
 
-			$gpLinkString = ($Configuration.Include | Sort-Object -Property @{ Expression = { $_.Tier }; Descending = $false }, Precedence -Descending | ForEach-Object {
-					$gpoDN = $GpoNameMapping[(Resolve-String -Text $_.PolicyName)]
-					if (-not $gpoDN) {
-						Write-PSFMessage -Level Warning -String 'Invoke-DMGPLink.New.GpoNotFound' -StringValues (Resolve-String -Text $_.PolicyName) -Target $ADObject -FunctionName Invoke-DMGPLink
-						return
-					}
-					$stateID = "0"
-					if ($_.State -eq 'Enforced') { $stateID = "2" }
-					if ($_.State -eq 'Disabled') { $stateID = "1" }
-					"[LDAP://$gpoDN;$stateID]"
-				}) -Join ""
+			$gpLinkString = @($Changes | Sort-Object -Property @{ Expression = { $_.Tier }; Descending = $false }, Precedence -Descending).ForEach{ $_.ToLink() } -Join ""
 			Write-PSFMessage -Level Debug -String 'Invoke-DMGPLink.New.NewGPLinkString' -StringValues $ADObject.DistinguishedName, $gpLinkString -Target $ADObject -FunctionName Invoke-DMGPLink
 			Set-ADObject @parameters -Identity $ADObject -Replace @{ gPLink = $gpLinkString } -ErrorAction Stop -Confirm:$false
 		}
@@ -149,6 +150,9 @@
 			)
 			$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
 
+			$allItems = $Configuration.Definition | Sort-Object -Property @{ Expression = { $_.Tier }; Descending = $false }, Precedence -Descending
+
+
 			$gpLinkString = ''
 			if ($Disable) {
 				$desiredDNs = $Configuration.ExtendedInclude.PolicyName | Resolve-String | ForEach-Object { $GpoNameMapping[$_] }
@@ -160,6 +164,8 @@
 			$gpLinkString += ($Configuration.ExtendedInclude | Where-Object DistinguishedName | Sort-Object -Property @{ Expression = { $_.Tier }; Descending = $false }, Precedence -Descending | ForEach-Object {
 					$_.ToLink()
 				}) -Join ""
+			#>
+
 			$msgParam = @{
 				Level        = 'SomewhatVerbose'
 				Tag          = 'change'
@@ -200,19 +206,19 @@
 				Stop-PSFFunction -String 'General.Invalid.Input' -StringValues 'Test-DMGPLink', $testItem -Target $testItem -Continue -EnableException $EnableException
 			}
 			
-			$countConfigured = ($testItem.Configuration | Measure-Object).Count
+			$countConfigured = ($testItem.Changed | Measure-Object).Count
 			$countActual = ($testItem.ADObject.LinkedGroupPolicyObjects | Measure-Object).Count
 			$countNotInConfig = ($testItem.ADObject.LinkedGroupPolicyObjects | Where-Object DistinguishedName -NotIn ($testItem.Configuration.PolicyName | Remove-PSFNull | Resolve-String | ForEach-Object { $gpoDisplayToDN[$_] }) | Measure-Object).Count
 
 			switch ($testItem.Type) {
 				'Delete' {
 					Invoke-PSFProtectedCommand -ActionString 'Invoke-DMGPLink.Delete.AllEnabled' -ActionStringValues $countActual -Target $testItem -ScriptBlock {
-						Clear-Link @parameters -ADObject $testItem.ADObject -Disable $Disable -ErrorAction Stop
+						Clear-Link @parameters -ADObject $testItem.ADObject -Disable $Disable -Changes $testItem.Changed -Definition $testItem.Configuration.Definition -ErrorAction Stop
 					} -EnableException $EnableException.ToBool() -PSCmdlet $PSCmdlet -Continue
 				}
 				'Create' {
 					Invoke-PSFProtectedCommand -ActionString 'Invoke-DMGPLink.New' -ActionStringValues $countConfigured -Target $testItem -ScriptBlock {
-						New-Link @parameters -ADObject $testItem.ADObject -Configuration $testItem.Configuration -GpoNameMapping $gpoDisplayToDN -ErrorAction Stop
+						New-Link @parameters -ADObject $testItem.ADObject -Changes $testItem.Changed -ErrorAction Stop
 					} -EnableException $EnableException.ToBool() -PSCmdlet $PSCmdlet -Continue
 				}
 				'Update' {

--- a/DomainManagement/functions/gplinks/Test-DMGPLink.ps1
+++ b/DomainManagement/functions/gplinks/Test-DMGPLink.ps1
@@ -165,6 +165,7 @@
 				if ($this.Status -eq 'Disabled') { $status = '1' }
 				if ($this.Status -eq 'Enforced') { $status = '2' }
 				if ($NewStatus -and $NewStatus -in '0','1','2') { $status = $NewStatus }
+
 				'[LDAP://{0};{1}]' -f $this.PolicyDN, $status
 			}
 			Add-Member -InputObject $update -MemberType ScriptMethod -Name ToString -Value {
@@ -305,25 +306,25 @@
 					if ($desired.DistinguishedName) {
 						$updateCommon.OriginalStatus = ''
 						New-LinkUpdate @updateCommon -Action Add
-						#New-Update -Action Add -PolicyName $desired.PolicyName -Status 'Enabled' -Identity $ADObject.DistinguishedName
+						# New-Update -Action Add -PolicyName $desired.PolicyName -Status 'Enabled' -Identity $ADObject.DistinguishedName
 						$index = $index + 1
 					}
 					else {
 						New-LinkUpdate @updateCommon -Action GpoMissing
-						#New-Update -Action GpoMissing -PolicyName $desired.PolicyName -Status 'Enabled' -Identity $ADObject.DistinguishedName
+						# New-Update -Action GpoMissing -PolicyName $desired.PolicyName -Status 'Enabled' -Identity $ADObject.DistinguishedName
 					}
 					continue
 				}
 				$updateCommon.OriginalPosition = ($currentSorted | Where-Object DisplayName -EQ $desired.PolicyName).Precedence
 				if ($index -gt @($currentSorted).Count -or $desired.PolicyName -ne $currentSorted[$index].DisplayName) {
 					New-LinkUpdate @updateCommon -Action Reorder
-					#New-Update -Action Reorder -PolicyName $desired.PolicyName -Status 'Enabled' -Identity $ADObject.DistinguishedName
+					# New-Update -Action Reorder -PolicyName $desired.PolicyName -Status 'Enabled' -Identity $ADObject.DistinguishedName
 					$index = $index + 1
 					continue
 				}
 				if (-not $desired.StateValid) {
 					New-LinkUpdate @updateCommon -Action State
-					#New-Update -Action State -PolicyName $desired.PolicyName -Status $desired.State -Identity $ADObject.DistinguishedName
+					# New-Update -Action State -PolicyName $desired.PolicyName -Status $desired.State -Identity $ADObject.DistinguishedName
 					$index = $index + 1
 					continue
 				}

--- a/DomainManagement/functions/gplinks/Test-DMGPLink.ps1
+++ b/DomainManagement/functions/gplinks/Test-DMGPLink.ps1
@@ -52,6 +52,7 @@
 					Include            = @()
 					Exclude            = @()
 					ExtendedInclude    = @()
+					Definition         = @()
 				}
 				$ous[$resolvedOU].Include = $script:groupPolicyLinks[$organizationalUnit].Values | Where-Object Present
 				$ous[$resolvedOU].Exclude = $script:groupPolicyLinks[$organizationalUnit].Values | Where-Object Present -EQ $false
@@ -74,6 +75,7 @@
 							Include            = @()
 							Exclude            = @()
 							ExtendedInclude    = @()
+							Definition         = @()
 						}
 					}
 					$container = $ous[$adObject.DistinguishedName]
@@ -105,6 +107,65 @@
 				Policy     = $PolicyName
 				Status     = $Status
 				Identity   = $Identity
+			}
+			Add-Member -InputObject $update -MemberType ScriptMethod -Name ToString -Value {
+				'{0}: {1}' -f $this.Action, $this.Policy
+			} -Force -PassThru
+		}
+		function New-LinkUpdate {
+			[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
+			[CmdletBinding()]
+			param (
+				[string]
+				$PolicyName,
+
+				[string]
+				$PolicyDN,
+
+				# The OU DN to which the link applies
+				[string]
+				$Identity,
+
+				[int]
+				$OriginalPosition,
+
+				[int]
+				$Tier,
+
+				[int]
+				$Precedence,
+
+				[string]
+				$Status,
+
+				[string]
+				$OriginalStatus,
+
+				[string]
+				$Action
+			)
+
+			$update = [PSCustomObject]@{
+				PSTypeName       = 'DomainManagement.GPLink.Update'
+				Policy           = $PolicyName
+				PolicyDN         = $PolicyDN
+				Identity         = $Identity
+				OriginalPosition = $OriginalPosition
+				Tier             = $Tier
+				Precedence       = $Precedence
+				Status           = $Status
+				OriginalStatus   = $OriginalStatus
+				Action           = $Action
+			}
+			Add-Member -InputObject $update -MemberType ScriptMethod -Name ToLink -Value {
+				param ($NewStatus)
+				if (-not $this.PolicyDN) { throw "Cannot generate Link for unknown GPO: $($this.Policy)" }
+				# [LDAP://cn={F4A6ADB1-BEDE-497D-901F-F24B19394951},cn=policies,cn=system,DC=contoso,DC=com;0][LDAP://cn={2036B9B6-D5C1-4756-B7AB-8291A9B26521},cn=policies,cn=system,DC=contoso,DC=com;0]
+				$status = '0'
+				if ($this.Status -eq 'Disabled') { $status = '1' }
+				if ($this.Status -eq 'Enforced') { $status = '2' }
+				if ($NewStatus -and $NewStatus -in '0','1','2') { $status = $NewStatus }
+				'[LDAP://{0};{1}]' -f $this.PolicyDN, $status
 			}
 			Add-Member -InputObject $update -MemberType ScriptMethod -Name ToString -Value {
 				'{0}: {1}' -f $this.Action, $this.Policy
@@ -230,31 +291,49 @@
 
 			$index = 0
 			foreach ($desired in $newDesiredState) {
+				$updateCommon = @{
+					PolicyName       = $desired.PolicyName
+					PolicyDN         = $desired.DistinguishedName
+					Status           = $desired.State
+					OriginalStatus   = $desired.State
+					OriginalPosition = -1
+					Tier             = $desired.Tier
+					Precedence       = $desired.Precedence
+					Identity         = $ADObject.DistinguishedName
+				}
 				if ($currentSorted.DisplayName -notcontains $desired.PolicyName) {
 					if ($desired.DistinguishedName) {
-						New-Update -Action Add -PolicyName $desired.PolicyName -Status 'Enabled' -Identity $ADObject.DistinguishedName
+						$updateCommon.OriginalStatus = ''
+						New-LinkUpdate @updateCommon -Action Add
+						#New-Update -Action Add -PolicyName $desired.PolicyName -Status 'Enabled' -Identity $ADObject.DistinguishedName
 						$index = $index + 1
 					}
 					else {
-						New-Update -Action GpoMissing -PolicyName $desired.PolicyName -Status 'Enabled' -Identity $ADObject.DistinguishedName
+						New-LinkUpdate @updateCommon -Action GpoMissing
+						#New-Update -Action GpoMissing -PolicyName $desired.PolicyName -Status 'Enabled' -Identity $ADObject.DistinguishedName
 					}
 					continue
 				}
+				$updateCommon.OriginalPosition = ($currentSorted | Where-Object DisplayName -EQ $desired.PolicyName).Precedence
 				if ($index -gt @($currentSorted).Count -or $desired.PolicyName -ne $currentSorted[$index].DisplayName) {
-					New-Update -Action Reorder -PolicyName $desired.PolicyName -Status 'Enabled' -Identity $ADObject.DistinguishedName
+					New-LinkUpdate @updateCommon -Action Reorder
+					#New-Update -Action Reorder -PolicyName $desired.PolicyName -Status 'Enabled' -Identity $ADObject.DistinguishedName
 					$index = $index + 1
 					continue
 				}
 				if (-not $desired.StateValid) {
-					New-Update -Action State -PolicyName $desired.PolicyName -Status $desired.State -Identity $ADObject.DistinguishedName
+					New-LinkUpdate @updateCommon -Action State
+					#New-Update -Action State -PolicyName $desired.PolicyName -Status $desired.State -Identity $ADObject.DistinguishedName
 					$index = $index + 1
 					continue
 				}
+				New-LinkUpdate @updateCommon -Action None
 				$index = $index + 1
 			}
 			foreach ($current in $currentSorted) {
 				if ($current.DisplayName -notin $newDesiredState.PolicyName) {
-					New-Update -Action Delete -PolicyName $current.DisplayName -Status $current.Status -Identity $ADObject.DistinguishedName
+					New-LinkUpdate -Action Delete -PolicyName $current.DisplayName -PolicyDN $current.DistinguishedName -Tier 0 -Precedence $current.Precedence -OriginalPosition $current.Precedence -Identity $ADObject.DistinguishedName
+					# New-Update -Action Delete -PolicyName $current.DisplayName -Status $current.Status -Identity $ADObject.DistinguishedName
 				}
 			}
 		}
@@ -286,7 +365,7 @@
 			catch {
 				Write-PSFMessage -String 'Test-DMGPLink.OUNotFound' -StringValues $ouDatum.OrganizationalUnit -ErrorRecord $_ -Tag 'panic', 'failed'
 				New-TestResult @resultDefaults -Type 'MissingParent'
-				Continue
+				continue
 			}
 			#endregion Handle AD Object doesn't exist
 
@@ -295,9 +374,10 @@
 			Add-Member -InputObject $adObject -MemberType NoteProperty -Name LinkedGroupPolicyObjects -Value $currentState -Force
 			if (-not $currentState) {
 				$updates = foreach ($includedLink in $ouDatum.Include) {
-					New-Update -Action Create -PolicyName $includedLink.PolicyName -Status $includedLink.State -Identity $ouDatum.OrganizationalUnit
+					New-LinkUpdate -Action Add -PolicyName $includedLink.PolicyName -PolicyDN $gpoDisplayToDN[$includedLink.PolicyName] -Status $includedLink.State -Tier $includedLink.Tier -Precedence $includedLink.Precedence -Identity $ouDatum.OrganizationalUnit
+					# New-Update -Action Create -PolicyName $includedLink.PolicyName -Status $includedLink.State -Identity $ouDatum.OrganizationalUnit
 				}
-				New-TestResult @resultDefaults -Type 'Create' -Changed $updates
+				New-TestResult @resultDefaults -Type 'Create' -Changed ($updates | Sort-Object -Property @{ Expression = { $_.Tier }; Descending = $false }, Precedence -Descending)
 				continue
 			}
 			#endregion Handle AD Object does not contain any links
@@ -308,11 +388,13 @@
 				else { 2 }
 			}
 			if ($updates.Action -contains 'GpoMissing') {
-				New-TestResult @resultDefaults -Type 'GpoMissing' -Changed $updates
+				New-TestResult @resultDefaults -Type 'GpoMissing' -Changed ($updates | Where-Object Action -NE 'None')
 				continue
 			}
-			if ($updates) {
-				New-TestResult @resultDefaults -Type 'Update' -Changed $updates
+			if ($updates | Where-Object Action -NE 'None') {
+				$test = New-TestResult @resultDefaults -Type 'Update' -Changed ($updates | Where-Object Action -NE 'None')
+				$test.Configuration.Definition = $updates
+				$test
 			}
 		}
 		#endregion Process Configuration
@@ -340,9 +422,10 @@
 			Add-Member -InputObject $adObject -MemberType NoteProperty -Name LinkedGroupPolicyObjects -Value $linkObjects -Force
 
 			$changes = foreach ($linkedObject in $linkObjects) {
-				New-Update -PolicyName $linkedObject.DisplayName -Status $linkedObject.Status -Action Delete -Identity $adObject.DistinguishedName
+				New-LinkUpdate -Action Delete -PolicyName $linkedObject.DisplayName -PolicyDN $linkedObject.DistinguishedName -Status $linkedObject.Status -OriginalStatus $linkedObject.Status -Identity $adObject.DistinguishedName
 			}
-			New-TestResult -ObjectType GPLink -Type 'Delete' -Identity $adObject.DistinguishedName -Server $Server -ADObject $adObject -Changed $changes
+			$configProxy = [PSCustomObject]@{ Definition = $changes }
+			New-TestResult -ObjectType GPLink -Type 'Delete' -Identity $adObject.DistinguishedName -Server $Server -ADObject $adObject -Configuration $configProxy -Changed $changes
 		}
 		#endregion Process Managed Estate
 	}

--- a/DomainManagement/functions/gpowner/Test-DMGPOwner.ps1
+++ b/DomainManagement/functions/gpowner/Test-DMGPOwner.ps1
@@ -96,7 +96,7 @@
 			$actualOwner = $actualAcl.GetOwner([System.Security.Principal.SecurityIdentifier])
 			if ("$actualOwner" -eq "$($desiredOwner.ObjectSID)") { continue }
 
-			try { $actualOwnerAD = Resolve-Principal @parameters -Name $actualOwner -OutputType ADObject }
+			try { $actualOwnerAD = Resolve-Principal @parameters -Name $actualOwner -OutputType ADObject -ErrorAction Stop }
 			catch { $actualOwnerAD = $null }
 
 			$change = [PSCustomObject]@{

--- a/DomainManagement/functions/gppermissions/Invoke-DMGPPermission.ps1
+++ b/DomainManagement/functions/gppermissions/Invoke-DMGPPermission.ps1
@@ -62,7 +62,7 @@
 		Set-DMDomainContext @parameters
 		$computerName = (Get-ADDomain @parameters).PDCEmulator
 		$psParameter = $PSBoundParameters | ConvertTo-PSFHashtable -Include ComputerName, Credential -Inherit
-		try { $session = New-PSSession @psParameter -ErrorAction Stop }
+		try { $session = New-AdcPSSession @psParameter -ErrorAction Stop }
 		catch {
 			Stop-PSFFunction -String 'Invoke-DMGPPermission.WinRM.Failed' -StringValues $computerName -ErrorRecord $_ -EnableException $EnableException -Cmdlet $PSCmdlet -Target $computerName
 			return

--- a/DomainManagement/functions/gppermissions/Test-DMGPPermission.ps1
+++ b/DomainManagement/functions/gppermissions/Test-DMGPPermission.ps1
@@ -44,7 +44,7 @@
 		Set-DMDomainContext @parameters
 		$computerName = (Get-ADDomain @parameters).PDCEmulator
 		$psParameter = $PSBoundParameters | ConvertTo-PSFHashtable -Include ComputerName, Credential -Inherit
-		try { $session = New-PSSession @psParameter -ErrorAction Stop }
+		try { $session = New-AdcPSSession @psParameter -ErrorAction Stop }
 		catch {
 			Stop-PSFFunction -String 'Test-DMGPPermission.WinRM.Failed' -StringValues $computerName -ErrorRecord $_ -EnableException $EnableException -Cmdlet $PSCmdlet -Target $computerName
 			return

--- a/DomainManagement/functions/gpregistrysettings/Test-DMGPRegistrySetting.ps1
+++ b/DomainManagement/functions/gpregistrysettings/Test-DMGPRegistrySetting.ps1
@@ -93,7 +93,7 @@
 			$pdcParameter = $parameters.Clone()
 			$pdcParameter.ComputerName = (Get-Domain2 @parameters).PDCEmulator
 			$pdcParameter.Remove('Server')
-			try { $session = New-PSSession @pdcParameter -ErrorAction Stop }
+			try { $session = New-AdcPSSession @pdcParameter -ErrorAction Stop }
 			catch {
 				Stop-PSFFunction -String 'Test-DMGPRegistrySetting.WinRM.Failed' -StringValues $parameters.Server -ErrorRecord $_ -EnableException $EnableException -Cmdlet $PSCmdlet -Target $parameters.Server
 				return

--- a/DomainManagement/functions/grouppolicies/Invoke-DMGroupPolicy.ps1
+++ b/DomainManagement/functions/grouppolicies/Invoke-DMGroupPolicy.ps1
@@ -73,7 +73,7 @@
 		Assert-Configuration -Type GroupPolicyObjects -Cmdlet $PSCmdlet
 		$computerName = (Get-ADDomain @parameters).PDCEmulator
 		$psParameter = $PSBoundParameters | ConvertTo-PSFHashtable -Include ComputerName, Credential -Inherit
-		try { $session = New-PSSession @psParameter -ErrorAction Stop }
+		try { $session = New-AdcPSSession @psParameter -ErrorAction Stop }
 		catch {
 			Stop-PSFFunction -String 'Invoke-DMGroupPolicy.WinRM.Failed' -StringValues $computerName -ErrorRecord $_ -EnableException $EnableException -Cmdlet $PSCmdlet -Target $computerName
 			return

--- a/DomainManagement/functions/grouppolicies/Test-DMGroupPolicy.ps1
+++ b/DomainManagement/functions/grouppolicies/Test-DMGroupPolicy.ps1
@@ -56,7 +56,7 @@
 
 		# PS Remoting
 		$psParameter = $PSBoundParameters | ConvertTo-PSFHashtable -Include ComputerName, Credential -Inherit
-		try { $session = New-PSSession @psParameter -ErrorAction Stop }
+		try { $session = New-AdcPSSession @psParameter -ErrorAction Stop }
 		catch {
 			Stop-PSFFunction -String 'Test-DMGroupPolicy.WinRM.Failed' -StringValues $computerName -ErrorRecord $_ -EnableException $EnableException -Cmdlet $PSCmdlet -Target $computerName
 			return

--- a/DomainManagement/functions/groups/Invoke-DMGroup.ps1
+++ b/DomainManagement/functions/groups/Invoke-DMGroup.ps1
@@ -1,5 +1,5 @@
 ﻿function Invoke-DMGroup {
-    <#
+	<#
 		.SYNOPSIS
 			Updates the group configuration of a domain to conform to the configured state.
 		
@@ -31,29 +31,29 @@
 
 			Updates the groups in the domain contoso.com to conform to configuration
 	#>
-    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
-    param (
-        [Parameter(ValueFromPipeline = $true)]
+	[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
+	param (
+		[Parameter(ValueFromPipeline = $true)]
 		$InputObject,
 		
 		[PSFComputer]
-        $Server,
+		$Server,
 		
-        [PSCredential]
-        $Credential,
+		[PSCredential]
+		$Credential,
 
-        [switch]
-        $EnableException
-    )
+		[switch]
+		$EnableException
+	)
 	
-    begin {
-        $parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
-        $parameters['Debug'] = $false
-        Assert-ADConnection @parameters -Cmdlet $PSCmdlet
-        Invoke-Callback @parameters -Cmdlet $PSCmdlet
-        Assert-Configuration -Type Groups -Cmdlet $PSCmdlet
-        Set-DMDomainContext @parameters
-    }
+	begin {
+		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
+		$parameters['Debug'] = $false
+		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
+		Invoke-Callback @parameters -Cmdlet $PSCmdlet
+		Assert-Configuration -Type Groups -Cmdlet $PSCmdlet
+		Set-DMDomainContext @parameters
+	}
 	process {
 		if (-not $InputObject) {
 			$InputObject = Test-DMGroup @parameters
@@ -65,61 +65,62 @@
 			}
 			
 			switch ($testItem.Type) {
-                'Delete' {
-                    Invoke-PSFProtectedCommand -ActionString 'Invoke-DMGroup.Group.Delete' -Target $testItem -ScriptBlock {
-                        Remove-ADGroup @parameters -Identity $testItem.ADObject.ObjectGUID -ErrorAction Stop -Confirm:$false
-                    } -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
-                }
-                'Create' {
-                    $targetOU = Resolve-String -Text $testItem.Configuration.Path
-                    try { $null = Get-ADObject @parameters -Identity $targetOU -ErrorAction Stop }
-                    catch { Stop-PSFFunction -String 'Invoke-DMGroup.Group.Create.OUExistsNot' -StringValues $targetOU, $testItem.Identity -Target $testItem -EnableException $EnableException -Continue }
-                    Invoke-PSFProtectedCommand -ActionString 'Invoke-DMGroup.Group.Create' -Target $testItem -ScriptBlock {
-                        $newParameters = $parameters.Clone()
-                        $newParameters += @{
-                            Name          = (Resolve-String -Text $testItem.Configuration.Name)
-                            Description   = (Resolve-String -Text $testItem.Configuration.Description)
-                            Path          = $targetOU
-                            GroupCategory = $testItem.Configuration.Category
-							GroupScope    = $testItem.Configuration.Scope
-							Confirm       = $false
-                        }
-                        New-ADGroup @newParameters
-                    } -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
-                }
-                'MultipleOldGroups' {
-                    Stop-PSFFunction -String 'Invoke-DMGroup.Group.MultipleOldGroups' -StringValues $testItem.Identity, ($testItem.ADObject.Name -join ', ') -Target $testItem -EnableException $EnableException -Continue -Tag 'group', 'critical', 'panic'
-                }
-                'Rename' {
-                    Invoke-PSFProtectedCommand -ActionString 'Invoke-DMGroup.Group.Rename' -ActionStringValues (Resolve-String -Text $testItem.Configuration.Name) -Target $testItem -ScriptBlock {
+				'Delete' {
+					Invoke-PSFProtectedCommand -ActionString 'Invoke-DMGroup.Group.Delete' -Target $testItem -ScriptBlock {
+						Remove-ADGroup @parameters -Identity $testItem.ADObject.ObjectGUID -ErrorAction Stop -Confirm:$false
+					} -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
+				}
+				'Create' {
+					$targetOU = Resolve-String -Text $testItem.Configuration.Path
+					try { $null = Get-ADObject @parameters -Identity $targetOU -ErrorAction Stop }
+					catch { Stop-PSFFunction -String 'Invoke-DMGroup.Group.Create.OUExistsNot' -StringValues $targetOU, $testItem.Identity -Target $testItem -EnableException $EnableException -Continue }
+					Invoke-PSFProtectedCommand -ActionString 'Invoke-DMGroup.Group.Create' -Target $testItem -ScriptBlock {
+						$newParameters = $parameters.Clone()
+						$newParameters += @{
+							Name           = (Resolve-String -Text $testItem.Configuration.Name)
+							SamAccountName = (Resolve-String -Text $testItem.Configuration.SamAccountName)
+							Description    = (Resolve-String -Text $testItem.Configuration.Description)
+							Path           = $targetOU
+							GroupCategory  = $testItem.Configuration.Category
+							GroupScope     = $testItem.Configuration.Scope
+							Confirm        = $false
+						}
+						New-ADGroup @newParameters
+					} -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
+				}
+				'MultipleOldGroups' {
+					Stop-PSFFunction -String 'Invoke-DMGroup.Group.MultipleOldGroups' -StringValues $testItem.Identity, ($testItem.ADObject.Name -join ', ') -Target $testItem -EnableException $EnableException -Continue -Tag 'group', 'critical', 'panic'
+				}
+				'Rename' {
+					Invoke-PSFProtectedCommand -ActionString 'Invoke-DMGroup.Group.Rename' -ActionStringValues (Resolve-String -Text $testItem.Configuration.Name) -Target $testItem -ScriptBlock {
 						Set-ADGroup @parameters -Identity $testItem.ADObject.ObjectGUID -SamAccountName (Resolve-String -Text $testItem.Configuration.SamAccountName) -ErrorAction Stop -Confirm:$false
 						if ((Resolve-String -Text $testItem.Configuration.Name) -cne $testItem.ADObject.Name) {
 							Rename-ADObject @parameters -Identity $testItem.ADObject.ObjectGUID -NewName (Resolve-String -Text $testItem.Configuration.Name) -ErrorAction Stop -Confirm:$false
 						}
-                    } -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
-                }
-                'Update' {
-                    if ($change = $testItem.Changed | Where-Object Property -eq 'Path') {
-                        $targetOU = $change.New
-                        try { $null = Get-ADObject @parameters -Identity $targetOU -ErrorAction Stop }
-                        catch { Stop-PSFFunction -String 'Invoke-DMGroup.Group.Update.OUExistsNot' -StringValues $testItem.Identity, $targetOU -Target $testItem -EnableException $EnableException -Continue }
+					} -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
+				}
+				'Update' {
+					if ($change = $testItem.Changed | Where-Object Property -EQ 'Path') {
+						$targetOU = $change.New
+						try { $null = Get-ADObject @parameters -Identity $targetOU -ErrorAction Stop }
+						catch { Stop-PSFFunction -String 'Invoke-DMGroup.Group.Update.OUExistsNot' -StringValues $testItem.Identity, $targetOU -Target $testItem -EnableException $EnableException -Continue }
 
-                        Invoke-PSFProtectedCommand -ActionString 'Invoke-DMGroup.Group.Move' -ActionStringValues $targetOU -Target $testItem -ScriptBlock {
-                            $null = Move-ADObject @parameters -Identity $testItem.ADObject.ObjectGUID -TargetPath $targetOU -ErrorAction Stop -Confirm:$false
-                        } -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
-                    }
-                    $changes = @{ }
-					foreach ($change in $testItem.Changed | Where-Object Property -in 'Description', 'Category') {
+						Invoke-PSFProtectedCommand -ActionString 'Invoke-DMGroup.Group.Move' -ActionStringValues $targetOU -Target $testItem -ScriptBlock {
+							$null = Move-ADObject @parameters -Identity $testItem.ADObject.ObjectGUID -TargetPath $targetOU -ErrorAction Stop -Confirm:$false
+						} -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
+					}
+					$changes = @{ }
+					foreach ($change in $testItem.Changed | Where-Object Property -In 'Description', 'Category') {
 						if ($change.Property -eq 'Description') { $changes['Description'] = $change.New }
 						if ($change.Property -eq 'Category') { $changes['GroupCategory'] = $change.New }
 					}
 					
-                    if ($changes.Keys.Count -gt 0) {
-                        Invoke-PSFProtectedCommand -ActionString 'Invoke-DMGroup.Group.Update' -ActionStringValues ($changes.Keys -join ", ") -Target $testItem -ScriptBlock {
-                            $null = Set-ADObject @parameters -Identity $testItem.ADObject.ObjectGUID -ErrorAction Stop -Replace $changes -Confirm:$false
-                        } -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
-                    }
-                    if ($testItem.Changed.Property -contains 'Scope') {
+					if ($changes.Keys.Count -gt 0) {
+						Invoke-PSFProtectedCommand -ActionString 'Invoke-DMGroup.Group.Update' -ActionStringValues ($changes.Keys -join ", ") -Target $testItem -ScriptBlock {
+							$null = Set-ADObject @parameters -Identity $testItem.ADObject.ObjectGUID -ErrorAction Stop -Replace $changes -Confirm:$false
+						} -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
+					}
+					if ($testItem.Changed.Property -contains 'Scope') {
 						$targetScope = Resolve-String -Text $testItem.Configuration.Scope
 						if ($targetScope -notin ([Enum]::GetNames([Microsoft.ActiveDirectory.Management.ADGroupScope]))) {
 							Stop-PSFFunction -String 'Invoke-DMGroup.Group.InvalidScope' -StringValues $testItem, $targetScope -Continue -EnableException $EnableException -Target $testItem
@@ -128,15 +129,15 @@
 						Invoke-PSFProtectedCommand -ActionString 'Invoke-DMGroup.Group.Update.Scope' -ActionStringValues $testItem, $testItem.ADObject.GroupScope, $targetScope -Target $testItem -ScriptBlock {
 							$null = Set-ADGroup @parameters -Identity $testItem.ADObject.ObjectGUID -GroupScope Universal -ErrorAction Stop -Confirm:$false
 							$null = Set-ADGroup @parameters -Identity $testItem.ADObject.ObjectGUID -GroupScope $targetScope -ErrorAction Stop -Confirm:$false
-                        } -EnableException $EnableException.ToBool() -PSCmdlet $PSCmdlet -Continue
+						} -EnableException $EnableException.ToBool() -PSCmdlet $PSCmdlet -Continue
 					}
-					if ($change = $testItem.Changed | Where-Object Property -eq 'Name') {
-                        Invoke-PSFProtectedCommand -ActionString 'Invoke-DMGroup.Group.Update.Name' -ActionStringValues $change.NewValue -Target $testItem -ScriptBlock {
-                            $testItem.ADObject | Rename-ADObject @parameters -NewName $change.New -ErrorAction Stop -Confirm:$false
-                        } -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
-                    }
-                }
-            }
-        }
-    }
+					if ($change = $testItem.Changed | Where-Object Property -EQ 'Name') {
+						Invoke-PSFProtectedCommand -ActionString 'Invoke-DMGroup.Group.Update.Name' -ActionStringValues $change.NewValue -Target $testItem -ScriptBlock {
+							$testItem.ADObject | Rename-ADObject @parameters -NewName $change.New -ErrorAction Stop -Confirm:$false
+						} -EnableException $EnableException -PSCmdlet $PSCmdlet -Continue
+					}
+				}
+			}
+		}
+	}
 }

--- a/DomainManagement/functions/organizationalunits/Invoke-DMOrganizationalUnit.ps1
+++ b/DomainManagement/functions/organizationalunits/Invoke-DMOrganizationalUnit.ps1
@@ -70,15 +70,15 @@
 	process {
 		#region Sort Script
 		$sortScript = {
-			if ($_.Type -eq 'ShouldDelete') { $_.ADObject.DistinguishedName.Split(",").Count }
-			else { 1000 - $_.Identity.Split(",").Count }
+			if ($_.Type -eq 'ShouldDelete') { 100 - $_.ADObject.DistinguishedName.Split(",").Count }
+			else { 1000 + $_.Identity.Split(",").Count }
 		}
 		#endregion Sort Script
 		if (-not $InputObject) {
 			$InputObject = Test-DMOrganizationalUnit @parameters
 		}
 		
-		:main foreach ($testItem in $InputObject | Sort-Object $sortScript -Descending) {
+		:main foreach ($testItem in $InputObject | Sort-Object $sortScript) {
 			# Catch invalid input - can only process test results
 			if ($testItem.PSObject.TypeNames -notcontains 'DomainManagement.OrganizationalUnit.TestResult') {
 				Stop-PSFFunction -String 'General.Invalid.Input' -StringValues 'Test-DMOrganizationalUnit', $testItem -Target $testItem -Continue -EnableException $EnableException

--- a/DomainManagement/functions/organizationalunits/Test-DMOrganizationalUnit.ps1
+++ b/DomainManagement/functions/organizationalunits/Test-DMOrganizationalUnit.ps1
@@ -38,8 +38,8 @@
 
 		#region Sort Script
 		$sortScript = {
-			if ($_.Type -eq 'ShouldDelete') { $_.ADObject.DistinguishedName.Split(",").Count }
-			else { 1000 - $_.Identity.Split(",").Count }
+			if ($_.Type -eq 'ShouldDelete') { 100 - $_.ADObject.DistinguishedName.Split(",").Count }
+			else { 1000 + $_.Identity.Split(",").Count }
 		}
 		#endregion Sort Script
 	}

--- a/DomainManagement/internal/functions/Get-Principal.ps1
+++ b/DomainManagement/internal/functions/Get-Principal.ps1
@@ -32,6 +32,10 @@
 	.PARAMETER Refresh
 		Do not use cached data, reload fresh data.
 
+	.PARAMETER Target
+		The target AD object this access rule applies to.
+		Used for logging only.
+
 	.PARAMETER Server
 		The server / domain to work with.
 	
@@ -69,6 +73,10 @@
 
 		[switch]
 		$Refresh,
+
+		[AllowEmptyString()]
+		[string]
+		$Target,
 
 		[PSFComputer]
 		$Server,
@@ -125,7 +133,8 @@
 			try { $adObject = Get-ADObject @parametersAD -LDAPFilter $filter -ErrorAction Stop -Properties * | Select-Object -First 1 }
 			catch { }
 			if (-not $adObject) {
-				Write-PSFMessage -Level Warning -String 'Get-Principal.Resolution.Failed' -StringValues $Sid, $Name, $ObjectClass, $Domain -Target $PSBoundParameters
+				if ($Target) { Write-PSFMessage -Level Warning -String 'Get-Principal.Resolution.FailedWithTarget' -StringValues $Sid, $Name, $ObjectClass, $Domain, $Target -Target $PSBoundParameters }
+				else { Write-PSFMessage -Level Warning -String 'Get-Principal.Resolution.Failed' -StringValues $Sid, $Name, $ObjectClass, $Domain -Target $PSBoundParameters }
 				throw
 			}
 		}

--- a/DomainManagement/internal/functions/acl_ace/Convert-AccessRuleIdentity.ps1
+++ b/DomainManagement/internal/functions/acl_ace/Convert-AccessRuleIdentity.ps1
@@ -14,6 +14,10 @@
 	
 	.PARAMETER Credential
 		The credentials to use for this operation.
+
+	.PARAMETER Target
+		The target AD object this access rule applies to.
+		Used for logging only.
 	
 	.EXAMPLE
 		PS C:\> $adAclObject.Access | Convert-AccessRuleIdentity @parameters
@@ -31,7 +35,10 @@
 		$Server,
 
 		[PSCredential]
-		$Credential
+		$Credential,
+
+		[string]
+		$Target
 	)
 	begin {
 		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
@@ -45,13 +52,13 @@
 			}
 			
 			if (-not $accessRule.IdentityReference.AccountDomainSid) {
-				try { $identity = Get-Principal @parameters -Sid $accessRule.IdentityReference -Domain $domainObject.DNSRoot -OutputType NTAccount }
+				try { $identity = Get-Principal @parameters -Sid $accessRule.IdentityReference -Domain $domainObject.DNSRoot -OutputType NTAccount -Target $Target }
 				catch {
 					# Empty Catch is OK here, warning happens in command
 				}
 			}
 			else {
-				try { $identity = Get-Principal @parameters -Sid $accessRule.IdentityReference -Domain $accessRule.IdentityReference -OutputType NTAccount }
+				try { $identity = Get-Principal @parameters -Sid $accessRule.IdentityReference -Domain $accessRule.IdentityReference -OutputType NTAccount -Target $Target}
 				catch {
 					# Empty Catch is OK here, warning happens in command
 				}


### PR DESCRIPTION
- Upd: General - Use the shared managed remoting feature, allowing configuring session options.
- Upd: AccessRules - when failing to resolve the identity of a principal on an existing access rule, the warning now reports the DN of the object
- Upd: Exchange - accepts test results as input for invoke
- Upd: GPLink - Supports cherry-picking results within a single OU.
- Fix: GPOwner - Prints red error messages on screen when failing to resovle the owner
- Fix: Groups - Ignores SamAccountName during creation of new groups