### PR TITLE
Unifying GP Component PDC Targeting

### DIFF
--- a/DomainManagement/DomainManagement.psd1
+++ b/DomainManagement/DomainManagement.psd1
@@ -3,7 +3,7 @@
 	RootModule         = 'DomainManagement.psm1'
 	
 	# Version number of this module.
-	ModuleVersion      = '1.9.234'
+	ModuleVersion      = '1.9.239'
 	
 	# ID used to uniquely identify this module
 	GUID               = '0a405382-ebc2-445b-8325-541535810193'

--- a/DomainManagement/changelog.md
+++ b/DomainManagement/changelog.md
@@ -1,5 +1,13 @@
 ﻿# Changelog
 
+## 1.9.239 (2025-11-13)
+
+- New: Configuration "DomainManagement.GroupPolicy.AlwaysUsePDC" - can be used to disable the Group Policy commands to prefer the PDC over the specified DC
+- Upd: Group Policy Permissions - will now by default consistently use the PDC Emulator, instead of the targeted server.
+- Upd: Group Policy - will now by default consistently use the PDC Emulator, instead of the targeted server.
+- Upd: Group Policy Link - will now by default consistently use the PDC Emulator.
+- Upd: Group Policy Owner - will now by default consistently use the PDC Emulator.
+
 ## 1.9.234 (2025-10-31)
 
 - Upd: General - Use the shared managed remoting feature, allowing configuring session options.

--- a/DomainManagement/en-us/strings.psd1
+++ b/DomainManagement/en-us/strings.psd1
@@ -183,6 +183,8 @@
 	
 	'Resolve-GPFilterMapping.Filter.Path.DoesNotExist.SilentlyContinue' = 'Issue resolving filter condition {0}: The specified path {1} could not be found, skipping.' # $Condition.Name, $searchBase
 	
+	'Resolve-GPTargetServer.Info.ChangingToPDC'                         = 'Changing target server from "{0}" to the PDC Emulator: "{1}". Group Policy components default to working against the PDC, as most GPO tools (including the default GPMC console) do the same. This behavior can be disabled in the module configuration settings.' # $Server, $domainObject.PDCEmulator
+
 	'Resolve-Identity.ParentObject.NoSecurityPrincipal'                 = 'Error processing parent of {0} : {1} of type {2} is no legal security principal and cannot be assigned permissions!' # $ADObject, $parentObject.Name, $parentObject.ObjectClass
 	
 	'Resolve-PolicyRevision.Result.ErrorOnConfigImport'                 = 'Failed to read configuration for {0}: {1}' # $Policy.DisplayName, $result.Error.Exception.Message

--- a/DomainManagement/functions/gplinks/Invoke-DMGPLink.ps1
+++ b/DomainManagement/functions/gplinks/Invoke-DMGPLink.ps1
@@ -48,6 +48,7 @@
 
 		Configures the current domain's group policy links as desired.
 	#>
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "")]
 	[CmdletBinding(SupportsShouldProcess = $true)]
 	param (
 		[Parameter(ValueFromPipeline = $true)]
@@ -209,7 +210,7 @@
 		}
 		#endregion Utility Functions
 
-		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
+		$parameters = Resolve-GPTargetServer -Server $Server -Credential $Credential
 		$parameters['Debug'] = $false
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet

--- a/DomainManagement/functions/gplinks/Test-DMGPLink.ps1
+++ b/DomainManagement/functions/gplinks/Test-DMGPLink.ps1
@@ -28,7 +28,7 @@
 	)
 	
 	begin {
-		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
+		$parameters = Resolve-GPTargetServer -Server $Server -Credential $Credential
 		$parameters['Debug'] = $false
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
@@ -352,7 +352,7 @@
 		$ouData = Get-OUData -Parameters $parameters
 		foreach ($ouDatum in $ouData) {
 			$resultDefaults = @{
-				Server        = $Server
+				Server        = $parameters.Server
 				ObjectType    = 'GPLink'
 				Identity      = $ouDatum.OrganizationalUnit
 				Configuration = $ouDatum
@@ -426,7 +426,7 @@
 				New-LinkUpdate -Action Delete -PolicyName $linkedObject.DisplayName -PolicyDN $linkedObject.DistinguishedName -Status $linkedObject.Status -OriginalStatus $linkedObject.Status -Identity $adObject.DistinguishedName
 			}
 			$configProxy = [PSCustomObject]@{ Definition = $changes }
-			New-TestResult -ObjectType GPLink -Type 'Delete' -Identity $adObject.DistinguishedName -Server $Server -ADObject $adObject -Configuration $configProxy -Changed $changes
+			New-TestResult -ObjectType GPLink -Type 'Delete' -Identity $adObject.DistinguishedName -Server $parameters.Server -ADObject $adObject -Configuration $configProxy -Changed $changes
 		}
 		#endregion Process Managed Estate
 	}

--- a/DomainManagement/functions/gpowner/Invoke-DMGPOwner.ps1
+++ b/DomainManagement/functions/gpowner/Invoke-DMGPOwner.ps1
@@ -49,7 +49,7 @@
 	)
 	
 	begin {
-		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
+		$parameters = Resolve-GPTargetServer -Server $Server -Credential $Credential
 		$parameters['Debug'] = $false
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet

--- a/DomainManagement/functions/gpowner/Test-DMGPOwner.ps1
+++ b/DomainManagement/functions/gpowner/Test-DMGPOwner.ps1
@@ -37,7 +37,7 @@
 	)
 	
 	begin {
-		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
+		$parameters = Resolve-GPTargetServer -Server $Server -Credential $Credential
 		$parameters['Debug'] = $false
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
@@ -88,7 +88,7 @@
 			try { $desiredOwner = Resolve-Principal @parameters -Name (Resolve-String -Text $ownerCfg.Identity) -OutputType ADObject -ErrorAction Stop }
 			catch {
 				Write-PSFMessage -Level Warning -String 'Test-DMGPOwner.Identity.NotFound' -StringValues $ownerCfg.Identity, $gpoADObject.DisplayName -Target $ownerCfg
-				New-TestResult -ObjectType GPOwner -Type IdentityNotFound -Identity $gpoADObject.DisplayName -Server $Server -Configuration $ownerCfg -ADObject $gpoADObject
+				New-TestResult -ObjectType GPOwner -Type IdentityNotFound -Identity $gpoADObject.DisplayName -Server $parameters.Server -Configuration $ownerCfg -ADObject $gpoADObject
 				continue
 			}
 			$actualAcl = Get-AdsAcl @parameters -Path $gpoADObject
@@ -112,7 +112,7 @@
 				'{0} -> {1}' -f $this.Old, $this.New
 			} -Force
 
-			New-TestResult -ObjectType GPOwner -Type Update -Identity $gpoADObject.DisplayName -Changed $change -Server $Server -Configuration $ownerCfg -ADObject $gpoADObject
+			New-TestResult -ObjectType GPOwner -Type Update -Identity $gpoADObject.DisplayName -Changed $change -Server $parameters.Server -Configuration $ownerCfg -ADObject $gpoADObject
 		}
 	}
 }

--- a/DomainManagement/functions/gppermissions/Invoke-DMGPPermission.ps1
+++ b/DomainManagement/functions/gppermissions/Invoke-DMGPPermission.ps1
@@ -54,17 +54,16 @@
 	
 	begin
 	{
-		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
+		$parameters = Resolve-GPTargetServer -Server $Server -Credential $Credential
 		$parameters['Debug'] = $false
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
 		Assert-Configuration -Type GroupPolicyPermissions -Cmdlet $PSCmdlet
 		Set-DMDomainContext @parameters
-		$computerName = (Get-ADDomain @parameters).PDCEmulator
-		$psParameter = $PSBoundParameters | ConvertTo-PSFHashtable -Include ComputerName, Credential -Inherit
+		$psParameter = Resolve-GPTargetServer -Server $Server -Credential $Credential -ForRemoting
 		try { $session = New-AdcPSSession @psParameter -ErrorAction Stop }
 		catch {
-			Stop-PSFFunction -String 'Invoke-DMGPPermission.WinRM.Failed' -StringValues $computerName -ErrorRecord $_ -EnableException $EnableException -Cmdlet $PSCmdlet -Target $computerName
+			Stop-PSFFunction -String 'Invoke-DMGPPermission.WinRM.Failed' -StringValues $parameters.Server -ErrorRecord $_ -EnableException $EnableException -Cmdlet $PSCmdlet -Target $parameters.Server
 			return
 		}
 

--- a/DomainManagement/functions/grouppolicies/Test-DMGroupPolicy.ps1
+++ b/DomainManagement/functions/grouppolicies/Test-DMGroupPolicy.ps1
@@ -38,27 +38,26 @@
 	)
 	
 	begin {
-		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential
+		$parameters = Resolve-GPTargetServer -Server $Server -Credential $Credential
 		$parameters['Debug'] = $false
 		Assert-ADConnection @parameters -Cmdlet $PSCmdlet
 		Invoke-Callback @parameters -Cmdlet $PSCmdlet
 		Assert-Configuration -Type GroupPolicyObjects -Cmdlet $PSCmdlet
 		Set-DMDomainContext @parameters
-		$computerName = (Get-ADDomain @parameters).PDCEmulator
 
 		# DomainData retrieval
 		$domainDataNames = ((Get-DMGroupPolicy).DisplayName | Get-DMGPRegistrySetting | Where-Object DomainData).DomainData | Select-Object -Unique
 		try { $null = $domainDataNames | Invoke-DMDomainData @parameters -EnableException }
 		catch {
-			Stop-PSFFunction -String 'Test-DMGroupPolicy.DomainData.Failed' -StringValues ($domainDataNames -join ",") -ErrorRecord $_ -EnableException $EnableException -Cmdlet $PSCmdlet -Target $computerName
+			Stop-PSFFunction -String 'Test-DMGroupPolicy.DomainData.Failed' -StringValues ($domainDataNames -join ",") -ErrorRecord $_ -EnableException $EnableException -Cmdlet $PSCmdlet -Target $parameters.Server
 			return
 		}
 
 		# PS Remoting
-		$psParameter = $PSBoundParameters | ConvertTo-PSFHashtable -Include ComputerName, Credential -Inherit
+		$psParameter = Resolve-GPTargetServer -Server $Server -Credential $Credential -ForRemoting
 		try { $session = New-AdcPSSession @psParameter -ErrorAction Stop }
 		catch {
-			Stop-PSFFunction -String 'Test-DMGroupPolicy.WinRM.Failed' -StringValues $computerName -ErrorRecord $_ -EnableException $EnableException -Cmdlet $PSCmdlet -Target $computerName
+			Stop-PSFFunction -String 'Test-DMGroupPolicy.WinRM.Failed' -StringValues $parameters.Server -ErrorRecord $_ -EnableException $EnableException -Cmdlet $PSCmdlet -Target $parameters.Server
 			return
 		}
 	}
@@ -66,7 +65,7 @@
 		if (Test-PSFFunctionInterrupt) { return }
 
 		$resultDefaults = @{
-			Server     = $Server
+			Server     = $parameters.Server
 			ObjectType = 'GroupPolicy'
 		}
 

--- a/DomainManagement/internal/configurations/configuration.ps1
+++ b/DomainManagement/internal/configurations/configuration.ps1
@@ -16,6 +16,7 @@ Set-PSFConfig -Module 'DomainManagement' -Name 'Import.IndividualFiles' -Value $
 
 Set-PSFConfig -Module 'DomainManagement' -Name 'ServiceAccount.SkipKdsCheck' -Value $false -Initialize -Validation bool -Description 'Whether the check for a KDS Root Key should be skipped. By default, Invoke-DMServiceAccount will validate the necessary key exists before creating gMSA. However, reading the key requires Domain Admin privileges, which may not always be available. Skipping the check will cause gMSA creation to fail with an error, if the KDSRootKey does not yet exist.'
 Set-PSFConfig -Module 'DomainManagement' -Name 'AccessRules.Remove.Option2' -Value $false -Initialize -Validation bool -Description 'In some environments, the default way of removing access rules have proved to not work out. Using this option enables a second way for removing access rules.'
+Set-PSFConfig -Module 'DomainManagement' -Name 'GroupPolicy.AlwaysUsePDC' -Value $true -Initialize -Validation bool -Description 'All Group Policy Consoles use by default the PDC Emulator. To make operations and visual verification match, Group Policy Components also use the PDC. This setting allows overriding that behavior.'
 
 #$coreCount = $env:NUMBER_OF_PROCESSORS
 #if (-not $coreCount) { $coreCount = 4 }

--- a/DomainManagement/internal/functions/groupPolicy/Resolve-GPTargetServer.ps1
+++ b/DomainManagement/internal/functions/groupPolicy/Resolve-GPTargetServer.ps1
@@ -1,0 +1,78 @@
+﻿function Resolve-GPTargetServer {
+	<#
+	.SYNOPSIS
+		Resolve the target to use for GPO Operations.
+		
+	.DESCRIPTION
+		Resolve the target to use for GPO Operations.
+		By default, all GPO Components work with the PDC Emulator, as it is the server targeted by all GPMC consoles.
+
+		It will also - once per session - remind the user, that the target was redirected to the PDC.
+		It returns a hashtable ready to use for splatting with AD commands, including Server and - if originally provided - Credential.
+	
+	.PARAMETER Server
+		The original server to target.
+	
+	.PARAMETER Credential
+		The credentials to use.
+	
+	.PARAMETER ForRemoting
+		We require the connection parameters for PowerShell Remoting.
+		Replaces "Server" with "ComputerName" in the resulting hashtable.
+	
+	.EXAMPLE
+		PS C:\> Resolve-GPTargetServer -Server dc1.contoso.com -Credential $cred
+
+		Returns a hashtable with the data required to execute AD commands (Keys "Server" & "Credential").
+		If the original target server was not the PDC emulator, it was replaced with the PDC from contoso.com.
+	#>
+	[outputType([hashtable])]
+	[CmdletBinding()]
+	param (
+		[Parameter(Mandatory = $true)]
+		[PSFComputer]
+		$Server,
+
+		[AllowNull()]
+		[PSCredential]
+		$Credential,
+
+		[switch]
+		$ForRemoting
+	)
+	begin {
+		if (-not $script:cache_GPDomainTarget) {
+			$script:cache_GPDomainTarget = @{}
+		}
+		$isEnabled = Get-PSFConfigValue -FullName 'DomainManagement.GroupPolicy.AlwaysUsePDC' -Fallback $true
+	}
+	process {
+		$adParam = @{ Server = $Server }
+		if ($Credential) { $adParam.Credential = $Credential }
+		
+		if (-not $isEnabled) {
+			if ($ForRemoting) {
+				$adParam.ComputerName = $adParam.Server
+				$adParam.Remove("Server")
+			}
+			return $adParam
+		}
+
+		if (-not $script:cache_GPDomainTarget["$Server"]) {
+			$script:cache_GPDomainTarget["$Server"] = Get-ADDomain @adParam
+		}
+		$domainObject = $script:cache_GPDomainTarget["$Server"]
+
+		if ($domainObject.PDCEmulator -ne $Server) {
+			if ($domainObject.DnsRoot -ne $Server) {
+				Write-PSFMessage -Level Host -String 'Resolve-GPTargetServer.Info.ChangingToPDC' -StringValues $Server, $domainObject.PDCEmulator -Target $domainObject.DnsRoot -Once "$($Server)->$($domainObject.PDCEmulator)"
+			}
+			$adParam.Server = $domainObject.PDCEmulator
+		}
+		if ($ForRemoting) {
+			$adParam.ComputerName = $adParam.Server
+			$adParam.Remove("Server")
+		}
+		return $adParam
+	}
+}

--- a/DomainManagement/internal/scripts/variables.ps1
+++ b/DomainManagement/internal/scripts/variables.ps1
@@ -1,9 +1,9 @@
 ﻿# NOTE: All variables in this file will be cleared when using Clear-DMConfiguration
 # That generally happens when switching between sets of configuration
 
- #----------------------------------------------------------------------------#
- #                               Configuration                                #
- #----------------------------------------------------------------------------#
+#----------------------------------------------------------------------------#
+#                               Configuration                                #
+#----------------------------------------------------------------------------#
 
 # Mapping table of values to insert
 $script:nameReplacementTable = @{ }
@@ -79,8 +79,8 @@ $script:wmifilter = @{ }
 
 
 #----------------------------------------------------------------------------#
- #                                Cached Data                                 #
- #----------------------------------------------------------------------------#
+#                                Cached Data                                 #
+#----------------------------------------------------------------------------#
 
 # Cached security principals, used by Get-Principal. Mapping to AD Objects
 $script:resolvedPrincipals = @{ }
@@ -98,49 +98,52 @@ $script:DNStoDomain = @{ }
 $script:DNStoDomainName = @{ }
 $script:NetBiostoDomain = @{ }
 
+# Domain Cache for GPO Target Server Calculation
+$script:cache_GPDomainTarget = @{}
 
- #----------------------------------------------------------------------------#
- #                                Context Data                                #
- #----------------------------------------------------------------------------#
+
+#----------------------------------------------------------------------------#
+#                                Context Data                                #
+#----------------------------------------------------------------------------#
 
 # Content Mode
 $script:contentMode = [PSCustomObject]@{
-    PSTypeName = 'DomainManagement.Content.Mode'
-    Mode    = 'Additive'
-    Include = @()
-    Exclude = @()
-    UserExcludePattern = @()
+	PSTypeName             = 'DomainManagement.Content.Mode'
+	Mode                   = 'Additive'
+	Include                = @()
+	Exclude                = @()
+	UserExcludePattern     = @()
 	RemoveUnknownWmiFilter = $false
 
 	# Note: Also update the help on Set-DMContentMode and on the website Content Mode documentation, when adding new entries here.
-	ExcludeComponents = @{
-		ACLs = $false
-		GPLinks = $false
-		GroupMembership = $false
-		Groups = $false
+	ExcludeComponents      = @{
+		ACLs                = $false
+		GPLinks             = $false
+		GroupMembership     = $false
+		Groups              = $false
 		OrganizationalUnits = $false
-		ServiceAccounts = $false
+		ServiceAccounts     = $false
 	}
 }
 $script:contentSearchBases = [PSCustomObject]@{
-    Include = @()
-    Exclude = @()
-    Bases   = @()
-    Server = ''
+	Include = @()
+	Exclude = @()
+	Bases   = @()
+	Server  = ''
 }
 
 # Domain Context
 $script:domainContext = [PSCustomObject]@{
-    Name = ''
-    Fqdn = ''
-    DN   = ''
-    ForestFqdn = ''
+	Name       = ''
+	Fqdn       = ''
+	DN         = ''
+	ForestFqdn = ''
 }
 
 #  Red Forest Context
 $script:redForestContext = [PSCustomObject]@{
-    Name = ''
-    Fqdn = ''
-    RootDomainFqdn = ''
-    RootDomainName = ''
+	Name           = ''
+	Fqdn           = ''
+	RootDomainFqdn = ''
+	RootDomainName = ''
 }

--- a/DomainManagement/tests/general/Help.Tests.ps1
+++ b/DomainManagement/tests/general/Help.Tests.ps1
@@ -87,7 +87,7 @@ foreach ($command in $commands) {
         
         Context "Test parameter help for $commandName" {
             
-            $common = 'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable', 'OutBuffer', 'OutVariable', 'PipelineVariable', 'Verbose', 'WarningAction', 'WarningVariable'
+            $common = 'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable', 'OutBuffer', 'OutVariable', 'PipelineVariable', 'Verbose', 'WarningAction', 'WarningVariable', 'ProgressAction'
             
             $parameters = $command.ParameterSets.Parameters | Sort-Object -Property Name -Unique | Where-Object Name -notin $common
             $parameterNames = $parameters.Name


### PR DESCRIPTION
- New: Configuration "DomainManagement.GroupPolicy.AlwaysUsePDC" - can be used to disable the Group Policy commands to prefer the PDC over the specified DC
- Upd: Group Policy Permissions - will now by default consistently use the PDC Emulator, instead of the targeted server.
- Upd: Group Policy - will now by default consistently use the PDC Emulator, instead of the targeted server.
- Upd: Group Policy Link - will now by default consistently use the PDC Emulator.
- Upd: Group Policy Owner - will now by default consistently use the PDC Emulator.